### PR TITLE
Fixes code-style issues and adds doxygen comments 

### DIFF
--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -1,3 +1,4 @@
+!> Set of subroutines to deal with forcing fields that may be used to drive MOM.
 module MOM_surface_forcing
 
 ! This file is part of MOM6. See LICENSE.md for the license.

--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -55,93 +55,92 @@ private apply_flux_adjustments
 private apply_force_adjustments
 private surface_forcing_end
 
-! surface_forcing_CS is a structure containing pointers to the forcing fields
-! which may be used to drive MOM.  All fluxes are positive downward.
+!> Contains pointers to the forcing fields which may be used to drive MOM.
+!! All fluxes are positive downward.
 type, public :: surface_forcing_CS ; private
-  integer :: wind_stagger       ! AGRID, BGRID_NE, or CGRID_NE (integer values
-                                ! from MOM_domains) to indicate the staggering of
-                                ! the winds that are being provided in calls to
-                                ! update_ocean_model.
-  logical :: use_temperature    ! If true, temp and saln used as state variables
+  integer :: wind_stagger       !< AGRID, BGRID_NE, or CGRID_NE (integer values
+                                !! from MOM_domains) to indicate the staggering of
+                                !! the winds that are being provided in calls to
+                                !! update_ocean_model.
+  logical :: use_temperature    !! If true, temp and saln used as state variables
   real :: wind_stress_multiplier !< A multiplier applied to incoming wind stress (nondim).
 
-  real :: Rho0                  ! Boussinesq reference density (kg/m^3)
-  real :: area_surf = -1.0      ! total ocean surface area (m^2)
-  real :: latent_heat_fusion    ! latent heat of fusion (J/kg)
-  real :: latent_heat_vapor     ! latent heat of vaporization (J/kg)
+  real :: Rho0                  !< Boussinesq reference density [kg/m^3]
+  real :: area_surf = -1.0      !< total ocean surface area [m^2]
+  real :: latent_heat_fusion    !< latent heat of fusion [J/kg]
+  real :: latent_heat_vapor     !< latent heat of vaporization [J/kg]
 
-  real :: max_p_surf            ! maximum surface pressure that can be
-                                ! exerted by the atmosphere and floating sea-ice,
-                                ! in Pa.  This is needed because the FMS coupling
-                                ! structure does not limit the water that can be
-                                ! frozen out of the ocean and the ice-ocean heat
-                                ! fluxes are treated explicitly.
-  logical :: use_limited_P_SSH  ! If true, return the sea surface height with
-                                ! the correction for the atmospheric (and sea-ice)
-                                ! pressure limited by max_p_surf instead of the
-                                ! full atmospheric pressure.  The default is true.
+  real :: max_p_surf            !< maximum surface pressure that can be
+                                !! exerted by the atmosphere and floating sea-ice,
+                                !! in Pa.  This is needed because the FMS coupling
+                                !! structure does not limit the water that can be
+                                !! frozen out of the ocean and the ice-ocean heat
+                                !! fluxes are treated explicitly.
+  logical :: use_limited_P_SSH  !< If true, return the sea surface height with
+                                !! the correction for the atmospheric (and sea-ice)
+                                !! pressure limited by max_p_surf instead of the
+                                !! full atmospheric pressure.  The default is true.
 
-  real :: gust_const            ! constant unresolved background gustiness for ustar (Pa)
-  logical :: read_gust_2d       ! If true, use a 2-dimensional gustiness supplied
-                                ! from an input file.
+  real :: gust_const            !< constant unresolved background gustiness for ustar [Pa]
+  logical :: read_gust_2d       !< If true, use a 2-dimensional gustiness supplied
+                                !! from an input file.
   real, pointer, dimension(:,:) :: &
-    TKE_tidal => NULL(), &      ! turbulent kinetic energy introduced to the
-                                ! bottom boundary layer by drag on the tidal flows,
-                                ! in W m-2.
-    gust => NULL(), &           ! spatially varying unresolved background
-                                ! gustiness that contributes to ustar (Pa).
-                                ! gust is used when read_gust_2d is true.
-    ustar_tidal => NULL()       ! tidal contribution to the bottom friction velocity (m/s)
-  real :: cd_tides              ! drag coefficient that applies to the tides (nondimensional)
-  real :: utide                 ! constant tidal velocity to use if read_tideamp
-                                ! is false, in m s-1.
-  logical :: read_tideamp       ! If true, spatially varying tidal amplitude read from a file.
+    TKE_tidal => NULL(), &      !< turbulent kinetic energy introduced to the
+                                !! bottom boundary layer by drag on the tidal flows [W m-2]
+    gust => NULL(), &           !< spatially varying unresolved background
+                                !! gustiness that contributes to ustar [Pa].
+                                !! gust is used when read_gust_2d is true.
+    ustar_tidal => NULL()       !< tidal contribution to the bottom friction velocity [m/s]
+  real :: cd_tides              !< drag coefficient that applies to the tides (nondimensional)
+  real :: utide                 !< constant tidal velocity to use if read_tideamp
+                                !! is false [m s-1]
+  logical :: read_tideamp       !< If true, spatially varying tidal amplitude read from a file.
 
-  logical :: rigid_sea_ice      ! If true, sea-ice exerts a rigidity that acts
-                                ! to damp surface deflections (especially surface
-                                ! gravity waves).  The default is false.
-  real    :: Kv_sea_ice         ! viscosity in sea-ice that resists sheared vertical motions (m^2/s)
-  real    :: density_sea_ice    ! typical density of sea-ice (kg/m^3). The value is
-                                ! only used to convert the ice pressure into
-                                ! appropriate units for use with Kv_sea_ice.
-  real    :: rigid_sea_ice_mass ! A mass per unit area of sea-ice beyond which
-                                ! sea-ice viscosity becomes effective, in kg m-2,
-                                ! typically of order 1000 kg m-2.
-  logical :: allow_flux_adjustments ! If true, use data_override to obtain flux adjustments
+  logical :: rigid_sea_ice      !< If true, sea-ice exerts a rigidity that acts
+                                !! to damp surface deflections (especially surface
+                                !! gravity waves).  The default is false.
+  real    :: Kv_sea_ice         !! viscosity in sea-ice that resists sheared vertical motions [m^2/s]
+  real    :: density_sea_ice    !< typical density of sea-ice [kg/m^3]. The value is
+                                !! only used to convert the ice pressure into
+                                !! appropriate units for use with Kv_sea_ice.
+  real    :: rigid_sea_ice_mass !< A mass per unit area of sea-ice beyond which
+                                !! sea-ice viscosity becomes effective, in kg m-2,
+                                !! typically of order 1000 [kg m-2].
+  logical :: allow_flux_adjustments !< If true, use data_override to obtain flux adjustments
 
-  real    :: Flux_const                     ! piston velocity for surface restoring (m/s)
-  logical :: salt_restore_as_sflux          ! If true, SSS restore as salt flux instead of water flux
-  logical :: adjust_net_srestore_to_zero    ! adjust srestore to zero (for both salt_flux or vprec)
-  logical :: adjust_net_srestore_by_scaling ! adjust srestore w/o moving zero contour
-  logical :: adjust_net_fresh_water_to_zero ! adjust net surface fresh-water (w/ restoring) to zero
-  logical :: use_net_FW_adjustment_sign_bug ! use the wrong sign when adjusting net FW
-  logical :: adjust_net_fresh_water_by_scaling ! adjust net surface fresh-water w/o moving zero contour
-  logical :: mask_srestore_under_ice        ! If true, use an ice mask defined by frazil
-                                            ! criteria for salinity restoring.
-  real    :: ice_salt_concentration         ! salt concentration for sea ice (kg/kg)
-  logical :: mask_srestore_marginal_seas    ! if true, then mask SSS restoring in marginal seas
-  real    :: max_delta_srestore             ! maximum delta salinity used for restoring
-  real    :: max_delta_trestore             ! maximum delta sst used for restoring
-  real, pointer, dimension(:,:) :: basin_mask => NULL() ! mask for SSS restoring by basin
+  real    :: Flux_const                     !< piston velocity for surface restoring [m/s]
+  logical :: salt_restore_as_sflux          !< If true, SSS restore as salt flux instead of water flux
+  logical :: adjust_net_srestore_to_zero    !< adjust srestore to zero (for both salt_flux or vprec)
+  logical :: adjust_net_srestore_by_scaling !< adjust srestore w/o moving zero contour
+  logical :: adjust_net_fresh_water_to_zero !< adjust net surface fresh-water (w/ restoring) to zero
+  logical :: use_net_FW_adjustment_sign_bug !< use the wrong sign when adjusting net FW
+  logical :: adjust_net_fresh_water_by_scaling !< adjust net surface fresh-water w/o moving zero contour
+  logical :: mask_srestore_under_ice        !< If true, use an ice mask defined by frazil
+                                            !< criteria for salinity restoring.
+  real    :: ice_salt_concentration         !< salt concentration for sea ice [kg/kg]
+  logical :: mask_srestore_marginal_seas    !< if true, then mask SSS restoring in marginal seas
+  real    :: max_delta_srestore             !< maximum delta salinity used for restoring
+  real    :: max_delta_trestore             !< maximum delta sst used for restoring
+  real, pointer, dimension(:,:) :: basin_mask => NULL() !< mask for SSS restoring by basin
 
-  type(diag_ctrl), pointer :: diag                  ! structure to regulate diagnostic output timing
-  character(len=200)       :: inputdir              ! directory where NetCDF input files are
-  character(len=200)       :: salt_restore_file     ! filename for salt restoring data
-  character(len=30)        :: salt_restore_var_name ! name of surface salinity in salt_restore_file
-  logical                  :: mask_srestore         ! if true, apply a 2-dimensional mask to the surface
-                                                    ! salinity restoring fluxes. The masking file should be
-                                                    ! in inputdir/salt_restore_mask.nc and the field should
-                                                    ! be named 'mask'
-  real, pointer, dimension(:,:) :: srestore_mask => NULL() ! mask for SSS restoring
-  character(len=200)       :: temp_restore_file     ! filename for sst restoring data
-  character(len=30)        :: temp_restore_var_name ! name of surface temperature in temp_restore_file
-  logical                  :: mask_trestore         ! if true, apply a 2-dimensional mask to the surface
-                                                    ! temperature restoring fluxes. The masking file should be
-                                                    ! in inputdir/temp_restore_mask.nc and the field should
-                                                    ! be named 'mask'
-  real, pointer, dimension(:,:) :: trestore_mask => NULL() ! mask for SST restoring
-  integer :: id_srestore = -1     ! id number for time_interp_external.
-  integer :: id_trestore = -1     ! id number for time_interp_external.
+  type(diag_ctrl), pointer :: diag                  !< structure to regulate diagnostic output timing
+  character(len=200)       :: inputdir              !< directory where NetCDF input files are
+  character(len=200)       :: salt_restore_file     !< filename for salt restoring data
+  character(len=30)        :: salt_restore_var_name !< name of surface salinity in salt_restore_file
+  logical                  :: mask_srestore         !< if true, apply a 2-dimensional mask to the surface
+                                                    !< salinity restoring fluxes. The masking file should be
+                                                    !< in inputdir/salt_restore_mask.nc and the field should
+                                                    !! be named 'mask'
+  real, pointer, dimension(:,:) :: srestore_mask => NULL() !< mask for SSS restoring
+  character(len=200)       :: temp_restore_file     !< filename for sst restoring data
+  character(len=30)        :: temp_restore_var_name !< name of surface temperature in temp_restore_file
+  logical                  :: mask_trestore         !< if true, apply a 2-dimensional mask to the surface
+                                                    !! temperature restoring fluxes. The masking file should be
+                                                    !! in inputdir/temp_restore_mask.nc and the field should
+                                                    !! be named 'mask'
+  real, pointer, dimension(:,:) :: trestore_mask => NULL() !< mask for SST restoring
+  integer :: id_srestore = -1     !< id number for time_interp_external.
+  integer :: id_trestore = -1     !< id number for time_interp_external.
 
   ! Diagnostics handles
   type(forcing_diags), public :: handles
@@ -151,40 +150,39 @@ type, public :: surface_forcing_CS ; private
   type(user_revise_forcing_CS), pointer :: urf_CS => NULL()
 end type surface_forcing_CS
 
-! ice_ocean_boundary_type is a structure corresponding to forcing, but with
-! the elements, units, and conventions that exactly conform to the use for
-! MOM-based coupled models.
+!> Structure corresponding to forcing, but with the elements, units, and conventions
+!! that exactly conform to the use for MOM-based coupled models.
 type, public :: ice_ocean_boundary_type
-  real, pointer, dimension(:,:) :: rofl_flux         =>NULL() !< liquid runoff (W/m2)
-  real, pointer, dimension(:,:) :: rofi_flux         =>NULL() !< ice runoff (W/m2)
-  real, pointer, dimension(:,:) :: u_flux            =>NULL() !< i-direction wind stress (Pa)
-  real, pointer, dimension(:,:) :: v_flux            =>NULL() !< j-direction wind stress (Pa)
-  real, pointer, dimension(:,:) :: t_flux            =>NULL() !< sensible heat flux (W/m2)
-  real, pointer, dimension(:,:) :: q_flux            =>NULL() !< specific humidity flux (kg/m2/s)
-  real, pointer, dimension(:,:) :: salt_flux         =>NULL() !< salt flux (kg/m2/s)
-  real, pointer, dimension(:,:) :: seaice_melt_heat  =>NULL() !< sea ice and snow melt heat flux (W/m2)
-  real, pointer, dimension(:,:) :: seaice_melt_water =>NULL() !< water flux due to sea ice and snow melting (kg/m2/s)
-  real, pointer, dimension(:,:) :: lw_flux           =>NULL() !< long wave radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_vis_dir   =>NULL() !< direct visible sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_vis_dif   =>NULL() !< diffuse visible sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_nir_dir   =>NULL() !< direct Near InfraRed sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: sw_flux_nir_dif   =>NULL() !< diffuse Near InfraRed sw radiation (W/m2)
-  real, pointer, dimension(:,:) :: lprec             =>NULL() !< mass flux of liquid precip (kg/m2/s)
-  real, pointer, dimension(:,:) :: fprec             =>NULL() !< mass flux of frozen precip (kg/m2/s)
-  real, pointer, dimension(:,:) :: runoff            =>NULL() !< mass flux of liquid runoff (kg/m2/s)
-  real, pointer, dimension(:,:) :: calving           =>NULL() !< mass flux of frozen runoff (kg/m2/s)
-  real, pointer, dimension(:,:) :: ustar_berg        =>NULL() !< frictional velocity beneath icebergs (m/s)
-  real, pointer, dimension(:,:) :: area_berg         =>NULL() !< area covered by icebergs(m2/m2)
+  real, pointer, dimension(:,:) :: rofl_flux         =>NULL() !< liquid runoff [W/m2]
+  real, pointer, dimension(:,:) :: rofi_flux         =>NULL() !< ice runoff [W/m2]
+  real, pointer, dimension(:,:) :: u_flux            =>NULL() !< i-direction wind stress [Pa]
+  real, pointer, dimension(:,:) :: v_flux            =>NULL() !< j-direction wind stress [Pa]
+  real, pointer, dimension(:,:) :: t_flux            =>NULL() !< sensible heat flux [W/m2]
+  real, pointer, dimension(:,:) :: q_flux            =>NULL() !< specific humidity flux [kg/m2/s]
+  real, pointer, dimension(:,:) :: salt_flux         =>NULL() !< salt flux [kg/m2/s]
+  real, pointer, dimension(:,:) :: seaice_melt_heat  =>NULL() !< sea ice and snow melt heat flux [W/m2]
+  real, pointer, dimension(:,:) :: seaice_melt_water =>NULL() !< water flux due to sea ice and snow melting [kg/m2/s]
+  real, pointer, dimension(:,:) :: lw_flux           =>NULL() !< long wave radiation [W/m2]
+  real, pointer, dimension(:,:) :: sw_flux_vis_dir   =>NULL() !< direct visible sw radiation [W/m2]
+  real, pointer, dimension(:,:) :: sw_flux_vis_dif   =>NULL() !< diffuse visible sw radiation [W/m2]
+  real, pointer, dimension(:,:) :: sw_flux_nir_dir   =>NULL() !< direct Near InfraRed sw radiation [W/m2]
+  real, pointer, dimension(:,:) :: sw_flux_nir_dif   =>NULL() !< diffuse Near InfraRed sw radiation [W/m2]
+  real, pointer, dimension(:,:) :: lprec             =>NULL() !< mass flux of liquid precip [kg/m2/s]
+  real, pointer, dimension(:,:) :: fprec             =>NULL() !< mass flux of frozen precip [kg/m2/s]
+  real, pointer, dimension(:,:) :: runoff            =>NULL() !< mass flux of liquid runoff [kg/m2/s]
+  real, pointer, dimension(:,:) :: calving           =>NULL() !< mass flux of frozen runoff [kg/m2/s]
+  real, pointer, dimension(:,:) :: ustar_berg        =>NULL() !< frictional velocity beneath icebergs [m/s]
+  real, pointer, dimension(:,:) :: area_berg         =>NULL() !< area covered by icebergs[m2/m2]
   real, pointer, dimension(:,:) :: mass_berg         =>NULL() !< mass of icebergs(kg/m2)
-  real, pointer, dimension(:,:) :: runoff_hflx       =>NULL() !< heat content of liquid runoff (W/m2)
-  real, pointer, dimension(:,:) :: calving_hflx      =>NULL() !< heat content of frozen runoff (W/m2)
+  real, pointer, dimension(:,:) :: runoff_hflx       =>NULL() !< heat content of liquid runoff [W/m2]
+  real, pointer, dimension(:,:) :: calving_hflx      =>NULL() !< heat content of frozen runoff [W/m2]
   real, pointer, dimension(:,:) :: p                 =>NULL() !< pressure of overlying ice and atmosphere
-                                                              !< on ocean surface (Pa)
-  real, pointer, dimension(:,:) :: mi                =>NULL() !< mass of ice (kg/m2)
+                                                              !< on ocean surface [Pa]
+  real, pointer, dimension(:,:) :: mi                =>NULL() !< mass of ice [kg/m2]
   real, pointer, dimension(:,:) :: ice_rigidity      =>NULL() !< rigidity of the sea ice, sea-ice and
                                                               !! ice-shelves, expressed as a coefficient
                                                               !! for divergence damping, as determined
-                                                              !! outside of the ocean model in (m3/s)
+                                                              !! outside of the ocean model in [m3/s]
   integer :: xtype                                            !< The type of the exchange - REGRID, REDIST or DIRECT
   type(coupler_2d_bc_type)      :: fluxes                     !< A structure that may contain an array of
                                                               !! named fields used for passive tracer fluxes.
@@ -197,9 +195,7 @@ end type ice_ocean_boundary_type
 
 integer :: id_clock_forcing
 
-!=======================================================================
 contains
-!=======================================================================
 
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! thermodynamic forcing type, including changes of units, sign conventions,
@@ -223,34 +219,34 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
   logical,       optional, intent(in)    :: restore_salt !< If true, salinity is restored to a target value.
   logical,       optional, intent(in)    :: restore_temp !< If true, temperature is restored to a target value.
 
-
+  ! local varibles
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    data_restore,  & ! The surface value toward which to restore (g/kg or degC)
-    SST_anom,      & ! Instantaneous sea surface temperature anomalies from a target value (deg C)
-    SSS_anom,      & ! Instantaneous sea surface salinity anomalies from a target value (g/kg)
-    SSS_mean,      & ! A (mean?) salinity about which to normalize local salinity
-                     ! anomalies when calculating restorative precipitation anomalies (g/kg)
-    PmE_adj,       & ! The adjustment to PminusE that will cause the salinity
-                     ! to be restored toward its target value (kg/(m^2 * s))
-    net_FW,        & ! The area integrated net freshwater flux into the ocean (kg/s)
-    net_FW2,       & ! The area integrated net freshwater flux into the ocean (kg/s)
-    work_sum,      & ! A 2-d array that is used as the work space for a global
-                     ! sum, used with units of m2 or (kg/s)
-    open_ocn_mask    ! a binary field indicating where ice is present based on frazil criteria
+    data_restore,  & !< The surface value toward which to restore [g/kg or degC]
+    SST_anom,      & !< Instantaneous sea surface temperature anomalies from a target value [deg C]
+    SSS_anom,      & !< Instantaneous sea surface salinity anomalies from a target value [g/kg]
+    SSS_mean,      & !< A (mean?) salinity about which to normalize local salinity
+                     !! anomalies when calculating restorative precipitation anomalies [g/kg]
+    PmE_adj,       & !< The adjustment to PminusE that will cause the salinity
+                     !! to be restored toward its target value [kg/(m^2 * s)]
+    net_FW,        & !< The area integrated net freshwater flux into the ocean [kg/s]
+    net_FW2,       & !< The area integrated net freshwater flux into the ocean [kg/s]
+    work_sum,      & !< A 2-d array that is used as the work space for a global
+                     !! sum, used with units of m2 or [kg/s]
+    open_ocn_mask    !< a binary field indicating where ice is present based on frazil criteria
 
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, i0, j0
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, isr, ier, jsr, jer
   integer :: isc_bnd, iec_bnd, jsc_bnd, jec_bnd
 
-  logical :: restore_salinity ! local copy of the argument restore_salt, if it
-                              ! is present, or false (no restoring) otherwise.
-  logical :: restore_sst      ! local copy of the argument restore_temp, if it
-                              ! is present, or false (no restoring) otherwise.
-  real :: delta_sss           ! temporary storage for sss diff from restoring value
-  real :: delta_sst           ! temporary storage for sst diff from restoring value
+  logical :: restore_salinity !< local copy of the argument restore_salt, if it
+                              !! is present, or false (no restoring) otherwise.
+  logical :: restore_sst      !< local copy of the argument restore_temp, if it
+                              !! is present, or false (no restoring) otherwise.
+  real :: delta_sss           !< temporary storage for sss diff from restoring value
+  real :: delta_sst           !< temporary storage for sst diff from restoring value
 
-  real :: C_p                 ! heat capacity of seawater ( J/(K kg) )
-  real :: sign_for_net_FW_bug ! Should be +1. but an old bug can be recovered by using -1.
+  real :: C_p                 !< heat capacity of seawater ( J/(K kg) )
+  real :: sign_for_net_FW_bug !< Should be +1. but an old bug can be recovered by using -1.
 
   call cpu_clock_begin(id_clock_forcing)
 
@@ -463,11 +459,11 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
     if (associated(IOB%t_flux)) &
       fluxes%sens(i,j) = IOB%t_flux(i-i0,j-j0) * G%mask2dT(i,j)
 
-    ! ! sea ice and snow melt heat flux (W/m2)
+    ! ! sea ice and snow melt heat flux [W/m2]
     ! if (associated(fluxes%seaice_melt_heat)) &
     !   fluxes%seaice_melt_heat(i,j) = G%mask2dT(i,j) * IOB%seaice_melt_heat(i-i0,j-j0)
 
-    ! ! water flux due to sea ice and snow melt (kg/m2/s)
+    ! ! water flux due to sea ice and snow melt [kg/m2/s]
     ! if (associated(fluxes%seaice_melt)) &
     !   fluxes%seaice_melt(i,j) = G%mask2dT(i,j) * IOB%seaice_melt_water(i-i0,j-j0)
 
@@ -590,8 +586,6 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, G, CS, &
 
 end subroutine convert_IOB_to_fluxes
 
-!=======================================================================
-
 !> This subroutine translates the Ice_ocean_boundary_type into a MOM
 !! mechanical forcing type, including changes of units, sign conventions,
 !! and putting the fields into arrays with MOM-standard halos.
@@ -607,26 +601,26 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
   type(surface_forcing_CS),pointer       :: CS     !< A pointer to the control structure returned by a
                                                    !! previous call to surface_forcing_init.
 
-
+  ! local variables
   real, dimension(SZIB_(G),SZJB_(G)) :: &
-    taux_at_q, & ! Zonal wind stresses at q points (Pa)
-    tauy_at_q    ! Meridional wind stresses at q points (Pa)
+    taux_at_q, & !< Zonal wind stresses at q points [Pa]
+    tauy_at_q    !< Meridional wind stresses at q points [Pa]
 
   real, dimension(SZI_(G),SZJ_(G)) :: &
-    rigidity_at_h, & ! Ice rigidity at tracer points (m3 s-1)
-    taux_at_h, & ! Zonal wind stresses at h points (Pa)
-    tauy_at_h    ! Meridional wind stresses at h points (Pa)
+    rigidity_at_h, & !< Ice rigidity at tracer points (m3 s-1)
+    taux_at_h, & !< Zonal wind stresses at h points [Pa]
+    tauy_at_h    !< Meridional wind stresses at h points [Pa]
 
-  real :: gustiness     ! unresolved gustiness that contributes to ustar (Pa)
-  real :: Irho0         ! inverse of the mean density in (m^3/kg)
-  real :: taux2, tauy2  ! squared wind stresses (Pa^2)
-  real :: tau_mag       ! magnitude of the wind stress (Pa)
-  real :: I_GEarth      ! 1.0 / G%G_Earth  (s^2/m)
-  real :: Kv_rho_ice    ! (CS%kv_sea_ice / CS%density_sea_ice) ( m^5/(s*kg) )
-  real :: mass_ice      ! mass of sea ice at a face (kg/m^2)
-  real :: mass_eff      ! effective mass of sea ice for rigidity (kg/m^2)
+  real :: gustiness     !< unresolved gustiness that contributes to ustar [Pa]
+  real :: Irho0         !< inverse of the mean density in (m^3/kg)
+  real :: taux2, tauy2  !< squared wind stresses (Pa^2)
+  real :: tau_mag       !< magnitude of the wind stress [Pa]
+  real :: I_GEarth      !< 1.0 / G%G_Earth  (s^2/m)
+  real :: Kv_rho_ice    !< (CS%kv_sea_ice / CS%density_sea_ice) ( m^5/(s*kg) )
+  real :: mass_ice      !< mass of sea ice at a face (kg/m^2)
+  real :: mass_eff      !< effective mass of sea ice for rigidity (kg/m^2)
 
-  integer :: wind_stagger  ! AGRID, BGRID_NE, or CGRID_NE (integers from MOM_domains)
+  integer :: wind_stagger  !< AGRID, BGRID_NE, or CGRID_NE (integers from MOM_domains)
   integer :: i, j, is, ie, js, je, Isq, Ieq, Jsq, Jeq, i0, j0
   integer :: isd, ied, jsd, jed, IsdB, IedB, JsdB, JedB, isr, ier, jsr, jer
   integer :: isc_bnd, iec_bnd, jsc_bnd, jec_bnd
@@ -876,8 +870,6 @@ subroutine convert_IOB_to_forces(IOB, forces, index_bounds, Time, G, CS)
   call cpu_clock_end(id_clock_forcing)
 end subroutine convert_IOB_to_forces
 
-!=======================================================================
-
 !> Adds thermodynamic flux adjustments obtained via data_override
 !! Component name is 'OCN'
 !! Available adjustments are:
@@ -891,7 +883,7 @@ subroutine apply_flux_adjustments(G, CS, Time, fluxes)
   type(forcing),            intent(inout) :: fluxes !< Surface fluxes structure
 
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G)) :: temp_at_h ! Fluxes at h points (W m-2 or kg m-2 s-1)
+  real, dimension(SZI_(G),SZJ_(G)) :: temp_at_h !< Fluxes at h points [W m-2 or kg m-2 s-1]
 
   integer :: isc, iec, jsc, jec, i, j
   logical :: overrode_h
@@ -923,8 +915,6 @@ subroutine apply_flux_adjustments(G, CS, Time, fluxes)
   ! Not needed? ! if (overrode_h) call pass_var(fluxes%vprec, G%Domain)
 end subroutine apply_flux_adjustments
 
-!=======================================================================
-
 !> Adds mechanical forcing adjustments obtained via data_override
 !! Component name is 'OCN'
 !! Available adjustments are:
@@ -937,8 +927,8 @@ subroutine apply_force_adjustments(G, CS, Time, forces)
   type(mech_forcing),       intent(inout) :: forces !< A structure with the driving mechanical forces
 
   ! Local variables
-  real, dimension(SZI_(G),SZJ_(G)) :: tempx_at_h ! Delta to zonal wind stress at h points (Pa)
-  real, dimension(SZI_(G),SZJ_(G)) :: tempy_at_h ! Delta to meridional wind stress at h points (Pa)
+  real, dimension(SZI_(G),SZJ_(G)) :: tempx_at_h !< Delta to zonal wind stress at h points [Pa]
+  real, dimension(SZI_(G),SZJ_(G)) :: tempy_at_h !< Delta to meridional wind stress at h points [Pa]
 
   integer :: isc, iec, jsc, jec, i, j
   real :: dLonDx, dLonDy, rDlon, cosA, sinA, zonal_tau, merid_tau
@@ -983,8 +973,6 @@ subroutine apply_force_adjustments(G, CS, Time, forces)
 
 end subroutine apply_force_adjustments
 
-!=======================================================================
-
 !> Save any restart files associated with the surface forcing.
 subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
                                 filename_suffix)
@@ -1004,8 +992,6 @@ subroutine forcing_save_restart(CS, G, Time, directory, time_stamped, &
   call save_restart(directory, Time, G, CS%restart_CSp, time_stamped)
 
 end subroutine forcing_save_restart
-
-!=======================================================================
 
 !> Initialize the surface forcing, including setting parameters and allocating permanent memory.
 subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, restore_temp)
@@ -1339,8 +1325,6 @@ subroutine surface_forcing_init(Time, G, param_file, diag, CS, restore_salt, res
   call cpu_clock_end(id_clock_forcing)
 end subroutine surface_forcing_init
 
-!=======================================================================
-
 !> Clean up and deallocate any memory associated with this module and its children.
 subroutine surface_forcing_end(CS, fluxes)
   type(surface_forcing_CS), pointer       :: CS !< A pointer to the control structure returned by
@@ -1359,8 +1343,6 @@ subroutine surface_forcing_end(CS, fluxes)
 
 end subroutine surface_forcing_end
 
-!=======================================================================
-
 !> Write out a set of messages with checksums of the fields in an ice_ocen_boundary type
 subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
 
@@ -1369,6 +1351,8 @@ subroutine ice_ocn_bnd_type_chksum(id, timestep, iobt)
   type(ice_ocean_boundary_type), &
                     intent(in) :: iobt   !< An ice-ocean boundary type with fluxes to drive the
                                          !! ocean in a coupled model whose checksums are reported
+
+  ! local variables
   integer ::   n,m, outunit
 
   outunit = stdout()

--- a/config_src/nuopc_driver/MOM_surface_forcing.F90
+++ b/config_src/nuopc_driver/MOM_surface_forcing.F90
@@ -1,4 +1,4 @@
-!> Set of subroutines to deal with forcing fields that may be used to drive MOM.
+!> Converts the input ESMF data (import data) to a MOM-specific data type (surface_forcing_CS).
 module MOM_surface_forcing
 
 ! This file is part of MOM6. See LICENSE.md for the license.

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -378,8 +378,9 @@ use ESMF,  only: ESMF_COORDSYS_SPH_DEG, ESMF_GridCreate, ESMF_INDEX_DELOCAL
 use ESMF,  only: ESMF_MESHLOC_ELEMENT, ESMF_RC_VAL_OUTOFRANGE, ESMF_StateGet
 use ESMF,  only: ESMF_TimePrint, ESMF_AlarmSet, ESMF_FieldGet
 
-!TODO, where this is comming from?
-! 1) ESMF_GridCompGetInternalState
+! TODO ESMF_GridCompGetInternalState does not have an explicit Fortran interface.
+!! Model does not compile with "use ESMF,  only: ESMF_GridCompGetInternalState"
+!! Is this okay?
 
 use NUOPC,       only: NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
 use NUOPC,       only: NUOPC_CompFilterPhaseMap, NUOPC_CompAttributeGet, NUOPC_CompAttributeAdd
@@ -2242,16 +2243,17 @@ subroutine State_SetScalar(value, scalar_id, State, mytask, scalar_name, scalar_
 
 end subroutine State_SetScalar
 
-!> TODO
+!> Realize the import and export fields using either a grid or a mesh.
 subroutine MOM_RealizeFields(state, nfields, field_defs, tag, grid, mesh, rc)
-
-  type(ESMF_State)    , intent(inout)        :: state
-  integer             , intent(in)           :: nfields
-  type(fld_list_type) , intent(inout)        :: field_defs(:)
-  character(len=*)    , intent(in)           :: tag
-  type(ESMF_Grid)     , intent(in), optional :: grid
-  type(ESMF_Mesh)     , intent(in), optional :: mesh
-  integer             , intent(inout)        :: rc
+  type(ESMF_State)    , intent(inout)        :: state !< ESMF_State object for
+                                                      !! import/export fields.
+  integer             , intent(in)           :: nfields !< Number of fields.
+  type(fld_list_type) , intent(inout)        :: field_defs(:) !< Structure with field's
+                                                              !! information.
+  character(len=*)    , intent(in)           :: tag !< Import or export.
+  type(ESMF_Grid)     , intent(in), optional :: grid!< ESMF grid.
+  type(ESMF_Mesh)     , intent(in), optional :: mesh!< ESMF mesh.
+  integer             , intent(inout)        :: rc  !< Return code.
 
   ! local variables
   integer                     :: i

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -384,11 +384,6 @@ use NUOPC_Model, &
   model_label_SetRunClock    => label_SetRunClock, &
   model_label_Finalize       => label_Finalize
 
-! TODO GMM, where are these coming from? thye do not have an explicit fortran interface
-! ESMF_GridCompGetInternalState
-!
-! And these?
-! ESMF_LOGERR_PASSTHRU
 implicit none; private
 
 public SetServices

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -352,7 +352,6 @@ use time_utils_mod,           only: esmf2fms_time
 
 use, intrinsic :: iso_fortran_env, only: output_unit
 
-! TODO add only below.
 use ESMF,  only: ESMF_ClockAdvance, ESMF_ClockGet, ESMF_ClockPrint
 use ESMF,  only: ESMF_ClockGetAlarm, ESMF_ClockGetNextTime, ESMF_ClockAdvance
 use ESMF,  only: ESMF_ClockSet, ESMF_Clock, ESMF_GeomType_Flag, ESMF_LOGMSG_INFO
@@ -360,7 +359,7 @@ use ESMF,  only: ESMF_Grid, ESMF_GridCreate, ESMF_GridAddCoord
 use ESMF,  only: ESMF_GridGetCoord, ESMF_GridAddItem, ESMF_GridGetItem
 use ESMF,  only: ESMF_GridComp, ESMF_GridCompSetEntryPoint, ESMF_GridCompGet
 use ESMF,  only: ESMF_LogFoundError, ESMF_LogWrite, ESMF_LogSetError
-use ESMF,  only: ESMF_LOGERR_PASSTHRU, ESMF_GridCompGetInternalState
+use ESMF,  only: ESMF_LOGERR_PASSTHRU, ESMF_KIND_R8, ESMF_RC_VAL_WRONG
 use ESMF,  only: ESMF_GEOMTYPE_MESH, ESMF_GEOMTYPE_GRID, ESMF_SUCCESS
 use ESMF,  only: ESMF_METHOD_INITIALIZE, ESMF_MethodRemove, ESMF_State
 use ESMF,  only: ESMF_LOGMSG_INFO, ESMF_RC_ARG_BAD, ESMF_VM, ESMF_Time
@@ -371,12 +370,22 @@ use ESMF,  only: ESMF_DistGridConnection, ESMF_StateItem_Flag, ESMF_KIND_I4
 use ESMF,  only: ESMF_KIND_I8, ESMF_FAILURE, ESMF_DistGridCreate, ESMF_MeshCreate
 use ESMF,  only: ESMF_FILEFORMAT_ESMFMESH, ESMF_DELayoutCreate, ESMF_DistGridConnectionSet
 use ESMF,  only: ESMF_DistGridGet, ESMF_STAGGERLOC_CORNER, ESMF_GRIDITEM_MASK
-use ESMF,  only: ESMF_TYPEKIND_I4, ESMF_TYPEKIND_R8, ESMF_STAGGERLOC_CENTER,
+use ESMF,  only: ESMF_TYPEKIND_I4, ESMF_TYPEKIND_R8, ESMF_STAGGERLOC_CENTER
 use ESMF,  only: ESMF_GRIDITEM_AREA, ESMF_Field, ESMF_ALARM, ESMF_VMLogMemInfo
 use ESMF,  only: ESMF_AlarmIsRinging, ESMF_AlarmRingerOff, ESMF_StateRemove
-use ESMF,  only: ESMF_FieldCreate
+use ESMF,  only: ESMF_FieldCreate, ESMF_LOGMSG_ERROR, ESMF_LOGMSG_WARNING
+use ESMF,  only: ESMF_COORDSYS_SPH_DEG, ESMF_GridCreate, ESMF_INDEX_DELOCAL
+use ESMF,  only: ESMF_MESHLOC_ELEMENT, ESMF_RC_VAL_OUTOFRANGE, ESMF_StateGet
+use ESMF,  only: ESMF_TimePrint, ESMF_AlarmSet, ESMF_FieldGet
 
-use NUOPC
+!TODO, where this is comming from?
+! 1) ESMF_GridCompGetInternalState
+
+use NUOPC,       only: NUOPC_CompDerive, NUOPC_CompSetEntryPoint, NUOPC_CompSpecialize
+use NUOPC,       only: NUOPC_CompFilterPhaseMap, NUOPC_CompAttributeGet, NUOPC_CompAttributeAdd
+use NUOPC,       only: NUOPC_Advertise, NUOPC_SetAttribute, NUOPC_IsUpdated, NUOPC_Write
+use NUOPC,       only: NUOPC_IsConnected, NUOPC_Realize, NUOPC_CompAttributeSet
+use NUOPC_Model, only: NUOPC_ModelGet
 use NUOPC_Model, &
   model_routine_SS           => SetServices, &
   model_label_Advance        => label_Advance, &

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -925,7 +925,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
             return
      endif
 
-  end if
+  endif
 
   ocean_public%is_ocean_pe = .true.
   if (len_trim(restartfile) > 0) then
@@ -1002,7 +1002,7 @@ subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
   else
     !call fld_list_add(fldsToOcn_num, fldsToOcn, "mass_of_overlying_sea_ice" , "will provide")
     !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_lev"                   , "will provide")
-  end if
+  endif
 
   !--------- import fields -------------
   call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_salt_rate"             , "will provide") ! from ice
@@ -1199,7 +1199,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
             file=__FILE__)) &
             return
      enddo
-  end if
+  endif
 
   !---------------------------------
   ! Create either a grid or a mesh
@@ -1250,7 +1250,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
 
      if (localPet == 0) then
         write(logunit,*)'mesh file for mom6 domain is ',trim(cvalue)
-     end if
+     endif
 
      ! recreate the mesh using the above distGrid
      EMesh = ESMF_MeshCreate(EMeshTemp, elementDistgrid=Distgrid, rc=rc)
@@ -1515,9 +1515,9 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
          dataPtr_ycen(i1,j1)  = ocean_grid%geolatT(ig,jg)
          if(grid_attach_area) then
            dataPtr_area(i1,j1)  = ocean_grid%areaT(ig,jg)
-         end if
-       end do
-     end do
+         endif
+       enddo
+     enddo
 
      jlast = jec
      if(jec == nyg)jlast = jec+1
@@ -1530,8 +1530,8 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
          ig = i + ocean_grid%isc - isc - 1
          dataPtr_xcor(i1,j1)  = ocean_grid%geolonBu(ig,jg)
          dataPtr_ycor(i1,j1)  = ocean_grid%geolatBu(ig,jg)
-       end do
-     end do
+       enddo
+     enddo
 
      write(tmpstr,*) subname//' mask = ',minval(dataPtr_mask),maxval(dataPtr_mask)
      call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
@@ -1567,7 +1567,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
          file=__FILE__)) &
          return
 
-  end if
+  endif
 
   !---------------------------------
   ! set scalar data in export state
@@ -1655,7 +1655,7 @@ subroutine DataInitialize(gcomp, rc)
           line=__LINE__, &
           file=__FILE__)) &
           return  ! bail out
-  end if
+  endif
 
   call ESMF_StateGet(exportState, itemCount=fieldCount, rc=rc)
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
@@ -1682,7 +1682,7 @@ subroutine DataInitialize(gcomp, rc)
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-  end do
+  enddo
   deallocate(fieldNameList)
 
   ! check whether all Fields in the exportState are "Updated"
@@ -1694,7 +1694,7 @@ subroutine DataInitialize(gcomp, rc)
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
-  end if
+  endif
 
   if(write_diagnostics) then
     call NUOPC_Write(exportState, fileNamePrefix='field_init_ocn_export_', &
@@ -1833,7 +1833,7 @@ subroutine ModelAdvance(gcomp, rc)
      call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype=runtype, rc=rc)
   else
      call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, rc=rc)
-  end if
+  endif
   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
        line=__LINE__, &
        file=__FILE__)) &
@@ -1962,7 +1962,7 @@ subroutine ModelAdvance(gcomp, rc)
 
      if (is_root_pe()) then
 	write(logunit,*) subname//' writing restart file ',trim(restartname)
-     end if
+     endif
   endif
 
   !---------------
@@ -2124,7 +2124,7 @@ subroutine ModelSetRunClock(gcomp, rc)
 	  file=__FILE__)) &
 	  return  ! bail out
 
-  end if
+  endif
 
   !--------------------------------
   ! Advance model clock to trigger alarms then reset model clock back to currtime
@@ -2195,7 +2195,7 @@ subroutine ocean_model_finalize(gcomp, rc)
      call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.false.)
   else
      call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.true.)
-  end if
+  endif
   call field_manager_end()
 
   call fms_io_exit()
@@ -2325,7 +2325,7 @@ subroutine MOM_RealizeFields(state, nfields, field_defs, tag, grid, mesh, rc)
 		return  ! bail out
 	   fldptr1d(:) = 0.0
 
-	end if
+	endif
 
       endif
 

--- a/config_src/nuopc_driver/mom_cap.F90
+++ b/config_src/nuopc_driver/mom_cap.F90
@@ -308,2098 +308,2097 @@
 !!
 !!
 module mom_cap_mod
-  use constants_mod,            only: constants_init
-  use diag_manager_mod,         only: diag_manager_init, diag_manager_end
-  use field_manager_mod,        only: field_manager_init, field_manager_end
-  use fms_mod,                  only: fms_init, fms_end, open_namelist_file, check_nml_error
-  use fms_mod,                  only: close_file, file_exist, uppercase
-  use fms_io_mod,               only: fms_io_exit
-  use mpp_domains_mod,          only: domain2d, mpp_get_compute_domain, mpp_get_compute_domains
-  use mpp_domains_mod,          only: mpp_get_ntile_count, mpp_get_pelist, mpp_get_global_domain
-  use mpp_domains_mod,          only: mpp_get_domain_npes
-  use mpp_io_mod,               only: mpp_open, MPP_RDONLY, MPP_ASCII, MPP_OVERWR, MPP_APPEND, mpp_close, MPP_SINGLE
-  use mpp_mod,                  only: input_nml_file, mpp_error, FATAL, NOTE, mpp_pe, mpp_npes, mpp_set_current_pelist
-  use mpp_mod,                  only: stdlog, stdout, mpp_root_pe, mpp_clock_id
-  use mpp_mod,                  only: mpp_clock_begin, mpp_clock_end, MPP_CLOCK_SYNC
-  use mpp_mod,                  only: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, MAXPES
-  use time_interp_external_mod, only: time_interp_external_init
-  use time_manager_mod,         only: set_calendar_type, time_type, increment_date
-  use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name
-  use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
-  use time_manager_mod,         only: operator( <= ), operator( < ), operator( >= )
-  use time_manager_mod,         only: operator( + ),  operator( - ), operator( / )
-  use time_manager_mod,         only: operator( * ), operator( /= ), operator( > )
-  use time_manager_mod,         only: date_to_string
-  use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
-  use MOM_domains,              only: MOM_infra_init, num_pes, root_pe, pe_here
-  use MOM_file_parser,          only: get_param, log_version, param_file_type, close_param_file
-  use MOM_get_input,            only: Get_MOM_Input, directories
-  use MOM_domains,              only: pass_var
-  use MOM_error_handler,        only: is_root_pe
-  use MOM_ocean_model,          only: ice_ocean_boundary_type
-  use MOM_grid,                 only: ocean_grid_type, get_global_grid_size
-  use MOM_ocean_model,          only: ocean_model_restart, ocean_public_type, ocean_state_type
-  use MOM_ocean_model,          only: ocean_model_init_sfc
-  use MOM_ocean_model,          only: ocean_model_init, update_ocean_model, ocean_model_end, get_ocean_grid
-  use mom_cap_time,             only: AlarmInit
-  use mom_cap_methods,          only: mom_import, mom_export, mom_set_geomtype
+use constants_mod,            only: constants_init
+use diag_manager_mod,         only: diag_manager_init, diag_manager_end
+use field_manager_mod,        only: field_manager_init, field_manager_end
+use fms_mod,                  only: fms_init, fms_end, open_namelist_file, check_nml_error
+use fms_mod,                  only: close_file, file_exist, uppercase
+use fms_io_mod,               only: fms_io_exit
+use mpp_domains_mod,          only: domain2d, mpp_get_compute_domain, mpp_get_compute_domains
+use mpp_domains_mod,          only: mpp_get_ntile_count, mpp_get_pelist, mpp_get_global_domain
+use mpp_domains_mod,          only: mpp_get_domain_npes
+use mpp_io_mod,               only: mpp_open, MPP_RDONLY, MPP_ASCII, MPP_OVERWR, MPP_APPEND, mpp_close, MPP_SINGLE
+use mpp_mod,                  only: input_nml_file, mpp_error, FATAL, NOTE, mpp_pe, mpp_npes, mpp_set_current_pelist
+use mpp_mod,                  only: stdlog, stdout, mpp_root_pe, mpp_clock_id
+use mpp_mod,                  only: mpp_clock_begin, mpp_clock_end, MPP_CLOCK_SYNC
+use mpp_mod,                  only: MPP_CLOCK_DETAILED, CLOCK_COMPONENT, MAXPES
+use time_interp_external_mod, only: time_interp_external_init
+use time_manager_mod,         only: set_calendar_type, time_type, increment_date
+use time_manager_mod,         only: set_time, set_date, get_time, get_date, month_name
+use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
+use time_manager_mod,         only: operator( <= ), operator( < ), operator( >= )
+use time_manager_mod,         only: operator( + ),  operator( - ), operator( / )
+use time_manager_mod,         only: operator( * ), operator( /= ), operator( > )
+use time_manager_mod,         only: date_to_string
+use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
+use MOM_domains,              only: MOM_infra_init, num_pes, root_pe, pe_here
+use MOM_file_parser,          only: get_param, log_version, param_file_type, close_param_file
+use MOM_get_input,            only: Get_MOM_Input, directories
+use MOM_domains,              only: pass_var
+use MOM_error_handler,        only: is_root_pe
+use MOM_ocean_model,          only: ice_ocean_boundary_type
+use MOM_grid,                 only: ocean_grid_type, get_global_grid_size
+use MOM_ocean_model,          only: ocean_model_restart, ocean_public_type, ocean_state_type
+use MOM_ocean_model,          only: ocean_model_init_sfc
+use MOM_ocean_model,          only: ocean_model_init, update_ocean_model, ocean_model_end, get_ocean_grid
+use mom_cap_time,             only: AlarmInit
+use mom_cap_methods,          only: mom_import, mom_export, mom_set_geomtype
 #ifdef CESMCOUPLED
-  use shr_file_mod,             only: shr_file_setLogUnit, shr_file_getLogUnit
+use shr_file_mod,             only: shr_file_setLogUnit, shr_file_getLogUnit
 #endif
-  use time_utils_mod,           only: esmf2fms_time
+use time_utils_mod,           only: esmf2fms_time
 
-  use, intrinsic :: iso_fortran_env, only: output_unit
+use, intrinsic :: iso_fortran_env, only: output_unit
 
-  use ESMF
-  use NUOPC
-  use NUOPC_Model, &
-    model_routine_SS           => SetServices, &
-    model_label_Advance        => label_Advance, &
-    model_label_DataInitialize => label_DataInitialize, &
-    model_label_SetRunClock    => label_SetRunClock, &
-    model_label_Finalize       => label_Finalize
+use ESMF
+use NUOPC
+use NUOPC_Model, &
+  model_routine_SS           => SetServices, &
+  model_label_Advance        => label_Advance, &
+  model_label_DataInitialize => label_DataInitialize, &
+  model_label_SetRunClock    => label_SetRunClock, &
+  model_label_Finalize       => label_Finalize
 
-  implicit none
-  private
+implicit none; private
 
-  public SetServices
+public SetServices
 
-  type ocean_internalstate_type
-    type(ocean_public_type),       pointer :: ocean_public_type_ptr
-    type(ocean_state_type),        pointer :: ocean_state_type_ptr
-    type(ice_ocean_boundary_type), pointer :: ice_ocean_boundary_type_ptr
-  end type
+type ocean_internalstate_type
+  type(ocean_public_type),       pointer :: ocean_public_type_ptr
+  type(ocean_state_type),        pointer :: ocean_state_type_ptr
+  type(ice_ocean_boundary_type), pointer :: ice_ocean_boundary_type_ptr
+end type
 
-  type ocean_internalstate_wrapper
-    type(ocean_internalstate_type), pointer :: ptr
-  end type
+type ocean_internalstate_wrapper
+  type(ocean_internalstate_type), pointer :: ptr
+end type
 
-  type fld_list_type
-    character(len=64) :: stdname
-    character(len=64) :: shortname
-    character(len=64) :: transferOffer
-  end type fld_list_type
+type fld_list_type
+  character(len=64) :: stdname
+  character(len=64) :: shortname
+  character(len=64) :: transferOffer
+end type fld_list_type
 
-  integer,parameter    :: fldsMax = 100
-  integer              :: fldsToOcn_num = 0
-  type (fld_list_type) :: fldsToOcn(fldsMax)
-  integer              :: fldsFrOcn_num = 0
-  type (fld_list_type) :: fldsFrOcn(fldsMax)
+integer,parameter    :: fldsMax = 100
+integer              :: fldsToOcn_num = 0
+type (fld_list_type) :: fldsToOcn(fldsMax)
+integer              :: fldsFrOcn_num = 0
+type (fld_list_type) :: fldsFrOcn(fldsMax)
 
-  integer              :: debug = 0
-  integer              :: import_slice = 1
-  integer              :: export_slice = 1
-  character(len=256)   :: tmpstr
-  logical              :: write_diagnostics = .false.
-  character(len=32)    :: runtype  ! run type
-  integer              :: logunit  ! stdout logging unit number
-  logical              :: profile_memory = .true.
-  logical              :: grid_attach_area = .false.
-  character(len=128)   :: scalar_field_name = ''
-  integer              :: scalar_field_count = 0
-  integer              :: scalar_field_idx_grid_nx = 0
-  integer              :: scalar_field_idx_grid_ny = 0
-  character(len=*),parameter :: u_file_u = &
-       __FILE__
+integer              :: debug = 0
+integer              :: import_slice = 1
+integer              :: export_slice = 1
+character(len=256)   :: tmpstr
+logical              :: write_diagnostics = .false.
+character(len=32)    :: runtype  ! run type
+integer              :: logunit  ! stdout logging unit number
+logical              :: profile_memory = .true.
+logical              :: grid_attach_area = .false.
+character(len=128)   :: scalar_field_name = ''
+integer              :: scalar_field_count = 0
+integer              :: scalar_field_idx_grid_nx = 0
+integer              :: scalar_field_idx_grid_ny = 0
+character(len=*),parameter :: u_file_u = &
+     __FILE__
 
 #ifdef CESMCOUPLED
-  logical :: cesm_coupled = .true.
-  type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
+logical :: cesm_coupled = .true.
+type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_MESH
 #else
-  logical :: cesm_coupled = .false.
-  type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_GRID
+logical :: cesm_coupled = .false.
+type(ESMF_GeomType_Flag) :: geomtype = ESMF_GEOMTYPE_GRID
 #endif
 
 !=======================================================================
 contains
 !=======================================================================
 
-  !===============================================================================
-  !> NUOPC SetService method is the only public entry point.
-  !! SetServices registers all of the user-provided subroutines
-  !! in the module with the NUOPC layer.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param rc return code
-  subroutine SetServices(gcomp, rc)
+!===============================================================================
+!> NUOPC SetService method is the only public entry point.
+!! SetServices registers all of the user-provided subroutines
+!! in the module with the NUOPC layer.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param rc return code
+subroutine SetServices(gcomp, rc)
 
-    type(ESMF_GridComp)  :: gcomp
-    integer, intent(out) :: rc
-    character(len=*),parameter  :: subname='(mom_cap:SetServices)'
+  type(ESMF_GridComp)  :: gcomp
+  integer, intent(out) :: rc
+  character(len=*),parameter  :: subname='(mom_cap:SetServices)'
 
-    rc = ESMF_SUCCESS
+  rc = ESMF_SUCCESS
 
-    ! the NUOPC model component will register the generic methods
-    call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  ! the NUOPC model component will register the generic methods
+  call NUOPC_CompDerive(gcomp, model_routine_SS, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    ! switching to IPD versions
-    call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      userRoutine=InitializeP0, phase=0, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  ! switching to IPD versions
+  call ESMF_GridCompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+    userRoutine=InitializeP0, phase=0, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    ! set entry point for methods that require specific implementation
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv03p1"/), userRoutine=InitializeAdvertise, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
-      phaseLabelList=(/"IPDv03p3"/), userRoutine=InitializeRealize, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  ! set entry point for methods that require specific implementation
+  call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+    phaseLabelList=(/"IPDv03p1"/), userRoutine=InitializeAdvertise, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call NUOPC_CompSetEntryPoint(gcomp, ESMF_METHOD_INITIALIZE, &
+    phaseLabelList=(/"IPDv03p3"/), userRoutine=InitializeRealize, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    !------------------
-    ! attach specializing method(s)
-    !------------------
+  !------------------
+  ! attach specializing method(s)
+  !------------------
 
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_DataInitialize, &
-      specRoutine=DataInitialize, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call NUOPC_CompSpecialize(gcomp, specLabel=model_label_DataInitialize, &
+    specRoutine=DataInitialize, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, &
-      specRoutine=ModelAdvance, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Advance, &
+    specRoutine=ModelAdvance, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, &
-         specRoutine=ModelSetRunClock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call ESMF_MethodRemove(gcomp, label=model_label_SetRunClock, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call NUOPC_CompSpecialize(gcomp, specLabel=model_label_SetRunClock, &
+       specRoutine=ModelSetRunClock, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, &
-      specRoutine=ocean_model_finalize, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call NUOPC_CompSpecialize(gcomp, specLabel=model_label_Finalize, &
+    specRoutine=ocean_model_finalize, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-  end subroutine SetServices
+end subroutine SetServices
 
-  !===============================================================================
+!===============================================================================
 
-  !> First initialize subroutine called by NUOPC.  The purpose
-  !! is to set which version of the Initialize Phase Definition (IPD)
-  !! to use.
-  !!
-  !! For this MOM cap, we are using IPDv01.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param importState an ESMF_State object for import fields
-  !! @param exportState an ESMF_State object for export fields
-  !! @param clock an ESMF_Clock object
-  !! @param rc return code
-  subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
-    type(ESMF_GridComp)   :: gcomp
-    type(ESMF_State)      :: importState, exportState
-    type(ESMF_Clock)      :: clock
-    integer, intent(out)  :: rc
+!> First initialize subroutine called by NUOPC.  The purpose
+!! is to set which version of the Initialize Phase Definition (IPD)
+!! to use.
+!!
+!! For this MOM cap, we are using IPDv01.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param importState an ESMF_State object for import fields
+!! @param exportState an ESMF_State object for export fields
+!! @param clock an ESMF_Clock object
+!! @param rc return code
+subroutine InitializeP0(gcomp, importState, exportState, clock, rc)
+  type(ESMF_GridComp)   :: gcomp
+  type(ESMF_State)      :: importState, exportState
+  type(ESMF_Clock)      :: clock
+  integer, intent(out)  :: rc
 
-    logical                     :: isPresent, isSet
-    integer                     :: iostat
-    character(len=64)           :: value, logmsg
-    character(len=*),parameter  :: subname='(mom_cap:InitializeP0)'
+  logical                     :: isPresent, isSet
+  integer                     :: iostat
+  character(len=64)           :: value, logmsg
+  character(len=*),parameter  :: subname='(mom_cap:InitializeP0)'
 
-    rc = ESMF_SUCCESS
+  rc = ESMF_SUCCESS
 
-    ! Switch to IPDv03 by filtering all other phaseMap entries
-    call NUOPC_CompFilterPhaseMap(gcomp, ESMF_METHOD_INITIALIZE, &
-         acceptStringList=(/"IPDv03p"/), rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  ! Switch to IPDv03 by filtering all other phaseMap entries
+  call NUOPC_CompFilterPhaseMap(gcomp, ESMF_METHOD_INITIALIZE, &
+       acceptStringList=(/"IPDv03p"/), rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-    write_diagnostics = .false.
-    call NUOPC_CompAttributeGet(gcomp, name="DumpFields", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) write_diagnostics=(trim(value)=="true")
+  write_diagnostics = .false.
+  call NUOPC_CompAttributeGet(gcomp, name="DumpFields", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) write_diagnostics=(trim(value)=="true")
 
-    write(logmsg,*) write_diagnostics
-    call ESMF_LogWrite('mom_cap:DumpFields = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  write(logmsg,*) write_diagnostics
+  call ESMF_LogWrite('mom_cap:DumpFields = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-    profile_memory = .false.
-    call NUOPC_CompAttributeGet(gcomp, name="ProfileMemory", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) profile_memory=(trim(value)=="true")
-    write(logmsg,*) profile_memory
-    call ESMF_LogWrite('mom_cap:ProfileMemory = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  profile_memory = .false.
+  call NUOPC_CompAttributeGet(gcomp, name="ProfileMemory", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) profile_memory=(trim(value)=="true")
+  write(logmsg,*) profile_memory
+  call ESMF_LogWrite('mom_cap:ProfileMemory = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-    grid_attach_area = .false.
-    call NUOPC_CompAttributeGet(gcomp, name="GridAttachArea", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) grid_attach_area=(trim(value)=="true")
-    write(logmsg,*) grid_attach_area
-    call ESMF_LogWrite('mom_cap:GridAttachArea = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  grid_attach_area = .false.
+  call NUOPC_CompAttributeGet(gcomp, name="GridAttachArea", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) grid_attach_area=(trim(value)=="true")
+  write(logmsg,*) grid_attach_area
+  call ESMF_LogWrite('mom_cap:GridAttachArea = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-    scalar_field_name = ""
-    call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) then
-       scalar_field_name = trim(value)
-       call ESMF_LogWrite('mom_cap:ScalarFieldName = '//trim(scalar_field_name), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
+  scalar_field_name = ""
+  call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) then
+     scalar_field_name = trim(value)
+     call ESMF_LogWrite('mom_cap:ScalarFieldName = '//trim(scalar_field_name), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
 
-    scalar_field_count = 0
-    call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldCount", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_count
-       if (iostat /= 0) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//": ScalarFieldCount not an integer: "//trim(value), &
-               line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return
-       endif
-       write(logmsg,*) scalar_field_count
-       call ESMF_LogWrite('mom_cap:ScalarFieldCount = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
+  scalar_field_count = 0
+  call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldCount", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) then
+     read(value, '(i)', iostat=iostat) scalar_field_count
+     if (iostat /= 0) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//": ScalarFieldCount not an integer: "//trim(value), &
+	     line=__LINE__, file=__FILE__, rcToReturn=rc)
+	return
+     endif
+     write(logmsg,*) scalar_field_count
+     call ESMF_LogWrite('mom_cap:ScalarFieldCount = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
 
-    scalar_field_idx_grid_nx = 0
-    call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldIdxGridNX", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_idx_grid_nx
-       if (iostat /= 0) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//": ScalarFieldIdxGridNX not an integer: "//trim(value), &
-               line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return
-       endif
-       write(logmsg,*) scalar_field_idx_grid_nx
-       call ESMF_LogWrite('mom_cap:ScalarFieldIdxGridNX = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
+  scalar_field_idx_grid_nx = 0
+  call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldIdxGridNX", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) then
+     read(value, '(i)', iostat=iostat) scalar_field_idx_grid_nx
+     if (iostat /= 0) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//": ScalarFieldIdxGridNX not an integer: "//trim(value), &
+	     line=__LINE__, file=__FILE__, rcToReturn=rc)
+	return
+     endif
+     write(logmsg,*) scalar_field_idx_grid_nx
+     call ESMF_LogWrite('mom_cap:ScalarFieldIdxGridNX = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
 
-    scalar_field_idx_grid_ny = 0
-    call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldIdxGridNY", value=value, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) then
-       read(value, '(i)', iostat=iostat) scalar_field_idx_grid_ny
-       if (iostat /= 0) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//": ScalarFieldIdxGridNY not an integer: "//trim(value), &
-               line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return
-       endif
-       write(logmsg,*) scalar_field_idx_grid_ny
-       call ESMF_LogWrite('mom_cap:ScalarFieldIdxGridNY = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
+  scalar_field_idx_grid_ny = 0
+  call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldIdxGridNY", value=value, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) then
+     read(value, '(i)', iostat=iostat) scalar_field_idx_grid_ny
+     if (iostat /= 0) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//": ScalarFieldIdxGridNY not an integer: "//trim(value), &
+	     line=__LINE__, file=__FILE__, rcToReturn=rc)
+	return
+     endif
+     write(logmsg,*) scalar_field_idx_grid_ny
+     call ESMF_LogWrite('mom_cap:ScalarFieldIdxGridNY = '//trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
 
-    call NUOPC_CompAttributeAdd(gcomp, &
-         attrList=(/'RestartFileToRead', 'RestartFileToWrite'/), rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  call NUOPC_CompAttributeAdd(gcomp, &
+       attrList=(/'RestartFileToRead', 'RestartFileToWrite'/), rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-  end subroutine
+end subroutine
 
-  !===============================================================================
+!===============================================================================
 
-  !> Called by NUOPC to advertise import and export fields.  "Advertise"
-  !! simply means that the standard names of all import and export
-  !! fields are supplied.  The NUOPC layer uses these to match fields
-  !! between components in the coupled system.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param importState an ESMF_State object for import fields
-  !! @param exportState an ESMF_State object for export fields
-  !! @param clock an ESMF_Clock object
-  !! @param rc return code
-  subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
-    type(ESMF_GridComp)                    :: gcomp
-    type(ESMF_State)                       :: importState, exportState
-    type(ESMF_Clock)                       :: clock
-    integer, intent(out)                   :: rc
+!> Called by NUOPC to advertise import and export fields.  "Advertise"
+!! simply means that the standard names of all import and export
+!! fields are supplied.  The NUOPC layer uses these to match fields
+!! between components in the coupled system.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param importState an ESMF_State object for import fields
+!! @param exportState an ESMF_State object for export fields
+!! @param clock an ESMF_Clock object
+!! @param rc return code
+subroutine InitializeAdvertise(gcomp, importState, exportState, clock, rc)
+  type(ESMF_GridComp)                    :: gcomp
+  type(ESMF_State)                       :: importState, exportState
+  type(ESMF_Clock)                       :: clock
+  integer, intent(out)                   :: rc
 
-    type(ESMF_VM)                          :: vm
-    type(ESMF_Time)                        :: MyTime
-    type(ESMF_TimeInterval)                :: TINT
-    type (ocean_public_type),      pointer :: ocean_public => NULL()
-    type (ocean_state_type),       pointer :: ocean_state => NULL()
-    type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
-    type(ocean_internalstate_wrapper)      :: ocean_internalstate
-    type(ocean_grid_type),         pointer :: ocean_grid => NULL()
-    type(time_type)                        :: Run_len      ! length of experiment
-    type(time_type)                        :: Time
-    type(time_type)                        :: Time_restart
-    type(time_type)                        :: DT
-    integer                                :: DT_OCEAN
-    integer                                :: isc,iec,jsc,jec
-    integer                                :: year=0, month=0, day=0, hour=0, minute=0, second=0
-    integer                                :: mpi_comm_mom
-    integer                                :: i,n
-    character(len=256)                     :: stdname, shortname
-    character(len=32)                      :: starttype            ! model start type
-    character(len=512)                     :: diro
-    character(len=512)                     :: logfile
-    character(ESMF_MAXSTR)                 :: cvalue
-    logical                                :: isPresent, isPresentDiro, isPresentLogfile, isSet
-    logical                                :: existflag
-    integer                                :: userRc
-    character(len=512)                     :: restartfile          ! Path/Name of restart file
-    character(len=*), parameter            :: subname='(mom_cap:InitializeAdvertise)'
+  type(ESMF_VM)                          :: vm
+  type(ESMF_Time)                        :: MyTime
+  type(ESMF_TimeInterval)                :: TINT
+  type (ocean_public_type),      pointer :: ocean_public => NULL()
+  type (ocean_state_type),       pointer :: ocean_state => NULL()
+  type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
+  type(ocean_internalstate_wrapper)      :: ocean_internalstate
+  type(ocean_grid_type),         pointer :: ocean_grid => NULL()
+  type(time_type)                        :: Run_len      ! length of experiment
+  type(time_type)                        :: Time
+  type(time_type)                        :: Time_restart
+  type(time_type)                        :: DT
+  integer                                :: DT_OCEAN
+  integer                                :: isc,iec,jsc,jec
+  integer                                :: year=0, month=0, day=0, hour=0, minute=0, second=0
+  integer                                :: mpi_comm_mom
+  integer                                :: i,n
+  character(len=256)                     :: stdname, shortname
+  character(len=32)                      :: starttype            ! model start type
+  character(len=512)                     :: diro
+  character(len=512)                     :: logfile
+  character(ESMF_MAXSTR)                 :: cvalue
+  logical                                :: isPresent, isPresentDiro, isPresentLogfile, isSet
+  logical                                :: existflag
+  integer                                :: userRc
+  character(len=512)                     :: restartfile          ! Path/Name of restart file
+  character(len=*), parameter            :: subname='(mom_cap:InitializeAdvertise)'
 !--------------------------------
 
-    rc = ESMF_SUCCESS
+  rc = ESMF_SUCCESS
 
-    call ESMF_LogWrite(subname//' enter', ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-
-    allocate(Ice_ocean_boundary)
-    !allocate(ocean_state) ! ocean_model_init allocate this pointer
-    allocate(ocean_public)
-    allocate(ocean_internalstate%ptr)
-    ocean_internalstate%ptr%ice_ocean_boundary_type_ptr => Ice_ocean_boundary
-    ocean_internalstate%ptr%ocean_public_type_ptr       => ocean_public
-    ocean_internalstate%ptr%ocean_state_type_ptr        => ocean_state
-
-    call ESMF_VMGetCurrent(vm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_VMGet(VM, mpiCommunicator=mpi_comm_mom, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockGet(CLOCK, currTIME=MyTime, TimeStep=TINT,  RC=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_TimeGet (MyTime, YY=YEAR, MM=MONTH, DD=DAY, H=HOUR, M=MINUTE, S=SECOND, RC=rc )
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    CALL ESMF_TimeIntervalGet(TINT, S=DT_OCEAN, RC=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call fms_init(mpi_comm_mom)
-    call constants_init
-    call field_manager_init
-    call set_calendar_type (JULIAN)
-    call diag_manager_init
-
-    ! this ocean connector will be driven at set interval
-    DT = set_time (DT_OCEAN, 0)
-    Time = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
-
-    ! rsd need to figure out how to get this without share code
-    !call shr_nuopc_get_component_instance(gcomp, inst_suffix, inst_index)
-    !inst_name = "OCN"//trim(inst_suffix)
-
-    ! reset shr logging to my log file
-    if (is_root_pe()) then
-       call NUOPC_CompAttributeGet(gcomp, name="diro", value=diro, &
-            isPresent=isPresentDiro, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call NUOPC_CompAttributeGet(gcomp, name="logfile", value=logfile, &
-            isPresent=isPresentLogfile, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       if (isPresentDiro .and. isPresentLogfile) then
-          open(newunit=logunit,file=trim(diro)//"/"//trim(logfile))
-       else
-          logunit = output_unit
-       endif
-    else
-       logunit = output_unit
-    endif
-
-    starttype = ""
-    call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, &
-         isPresent=isPresent, isSet=isSet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-    if (isPresent .and. isSet) then
-       read(cvalue,*) starttype
-    else
-       call ESMF_LogWrite('mom_cap:start_type unset - using input.nml for restart option', &
-            ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
-
-    runtype = ""
-    if (trim(starttype) == trim('startup')) then
-       runtype = "initial"
-    else if (trim(starttype) == trim('continue') ) then
-       runtype = "continue"
-    else if (trim(starttype) == trim('branch')) then
-       runtype = "continue"
-    else if (len_trim(starttype) > 0) then
-       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-            msg=subname//": unknown starttype - "//trim(starttype), &
-            line=__LINE__, file=__FILE__, rcToReturn=rc)
+  call ESMF_LogWrite(subname//' enter', ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
        return
-    endif
 
-    if (len_trim(runtype) > 0) then
-       call ESMF_LogWrite('mom_cap:startup = '//trim(runtype), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-    endif
+  allocate(Ice_ocean_boundary)
+  !allocate(ocean_state) ! ocean_model_init allocate this pointer
+  allocate(ocean_public)
+  allocate(ocean_internalstate%ptr)
+  ocean_internalstate%ptr%ice_ocean_boundary_type_ptr => Ice_ocean_boundary
+  ocean_internalstate%ptr%ocean_public_type_ptr       => ocean_public
+  ocean_internalstate%ptr%ocean_state_type_ptr        => ocean_state
 
-    restartfile = ""
-    if (runtype == "initial") then
-       ! startup (new run) - 'n' is needed below if we don't specify input_filename in input.nml
-       restartfile = "n"
-    else if (runtype == "continue") then ! hybrid or branch or continuos runs
+  call ESMF_VMGetCurrent(vm, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-       ! optionally call into system-specific implementation to get restart file name
-       call ESMF_MethodExecute(gcomp, label="GetRestartFileToRead", &
-            existflag=existflag, userRc=userRc, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if (existflag) then
-          call ESMF_LogWrite('mom_cap: called user GetRestartFileToRead', ESMF_LOGMSG_INFO, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return
-       endif
+  call ESMF_VMGet(VM, mpiCommunicator=mpi_comm_mom, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-       call NUOPC_CompAttributeGet(gcomp, name='RestartFileToRead', &
-            value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       if (isPresent .and. isSet) then
-          restartfile = trim(cvalue)
-          call ESMF_LogWrite('mom_cap: RestartFileToRead = '//trim(restartfile), ESMF_LOGMSG_INFO, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return
-       else
-          call ESMF_LogWrite('mom_cap: restart requested, no RestartFileToRead attribute provided-will use input.nml',&
-               ESMF_LOGMSG_WARNING, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return
-       endif
+  call ESMF_ClockGet(CLOCK, currTIME=MyTime, TimeStep=TINT,  RC=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    end if
+  call ESMF_TimeGet (MyTime, YY=YEAR, MM=MONTH, DD=DAY, H=HOUR, M=MINUTE, S=SECOND, RC=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    ocean_public%is_ocean_pe = .true.
-    if (len_trim(restartfile) > 0) then
-       call ocean_model_init(ocean_public, ocean_state, Time, Time, input_restart_file=trim(restartfile))
-    else
-       call ocean_model_init(ocean_public, ocean_state, Time, Time)
-    endif
+  CALL ESMF_TimeIntervalGet(TINT, S=DT_OCEAN, RC=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    call ocean_model_init_sfc(ocean_state, ocean_public)
+  call fms_init(mpi_comm_mom)
+  call constants_init
+  call field_manager_init
+  call set_calendar_type (JULIAN)
+  call diag_manager_init
 
-    call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
+  ! this ocean connector will be driven at set interval
+  DT = set_time (DT_OCEAN, 0)
+  Time = set_date (YEAR,MONTH,DAY,HOUR,MINUTE,SECOND)
 
-    allocate ( Ice_ocean_boundary% u_flux (isc:iec,jsc:jec),          &
-               Ice_ocean_boundary% v_flux (isc:iec,jsc:jec),          &
-               Ice_ocean_boundary% t_flux (isc:iec,jsc:jec),          &
-               Ice_ocean_boundary% q_flux (isc:iec,jsc:jec),          &
-               Ice_ocean_boundary% salt_flux (isc:iec,jsc:jec),       &
-               Ice_ocean_boundary% lw_flux (isc:iec,jsc:jec),         &
-               Ice_ocean_boundary% sw_flux_vis_dir (isc:iec,jsc:jec), &
-               Ice_ocean_boundary% sw_flux_vis_dif (isc:iec,jsc:jec), &
-               Ice_ocean_boundary% sw_flux_nir_dir (isc:iec,jsc:jec), &
-               Ice_ocean_boundary% sw_flux_nir_dif (isc:iec,jsc:jec), &
-               Ice_ocean_boundary% lprec (isc:iec,jsc:jec),           &
-               Ice_ocean_boundary% fprec (isc:iec,jsc:jec),           &
-               Ice_ocean_boundary% mi (isc:iec,jsc:jec),              &
-               Ice_ocean_boundary% p (isc:iec,jsc:jec),               &
-               Ice_ocean_boundary% runoff (isc:iec,jsc:jec),          &
-               Ice_ocean_boundary% calving (isc:iec,jsc:jec),         &
-               Ice_ocean_boundary% runoff_hflx (isc:iec,jsc:jec),     &
-               Ice_ocean_boundary% calving_hflx (isc:iec,jsc:jec),    &
-               Ice_ocean_boundary% rofl_flux (isc:iec,jsc:jec),       &
-               Ice_ocean_boundary% rofi_flux (isc:iec,jsc:jec))
+  ! rsd need to figure out how to get this without share code
+  !call shr_nuopc_get_component_instance(gcomp, inst_suffix, inst_index)
+  !inst_name = "OCN"//trim(inst_suffix)
 
-    Ice_ocean_boundary%u_flux          = 0.0
-    Ice_ocean_boundary%v_flux          = 0.0
-    Ice_ocean_boundary%t_flux          = 0.0
-    Ice_ocean_boundary%q_flux          = 0.0
-    Ice_ocean_boundary%salt_flux       = 0.0
-    Ice_ocean_boundary%lw_flux         = 0.0
-    Ice_ocean_boundary%sw_flux_vis_dir = 0.0
-    Ice_ocean_boundary%sw_flux_vis_dif = 0.0
-    Ice_ocean_boundary%sw_flux_nir_dir = 0.0
-    Ice_ocean_boundary%sw_flux_nir_dif = 0.0
-    Ice_ocean_boundary%lprec           = 0.0
-    Ice_ocean_boundary%fprec           = 0.0
-    Ice_ocean_boundary%mi              = 0.0
-    Ice_ocean_boundary%p               = 0.0
-    Ice_ocean_boundary%runoff          = 0.0
-    Ice_ocean_boundary%calving         = 0.0
-    Ice_ocean_boundary%runoff_hflx     = 0.0
-    Ice_ocean_boundary%calving_hflx    = 0.0
-    Ice_ocean_boundary%rofl_flux       = 0.0
-    Ice_ocean_boundary%rofi_flux       = 0.0
+  ! reset shr logging to my log file
+  if (is_root_pe()) then
+     call NUOPC_CompAttributeGet(gcomp, name="diro", value=diro, &
+	  isPresent=isPresentDiro, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call NUOPC_CompAttributeGet(gcomp, name="logfile", value=logfile, &
+	  isPresent=isPresentLogfile, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     if (isPresentDiro .and. isPresentLogfile) then
+	open(newunit=logunit,file=trim(diro)//"/"//trim(logfile))
+     else
+	logunit = output_unit
+     endif
+  else
+     logunit = output_unit
+  endif
 
-    ocean_internalstate%ptr%ocean_state_type_ptr => ocean_state
-    call ESMF_GridCompSetInternalState(gcomp, ocean_internalstate, rc)
+  starttype = ""
+  call NUOPC_CompAttributeGet(gcomp, name='start_type', value=cvalue, &
+       isPresent=isPresent, isSet=isSet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+  if (isPresent .and. isSet) then
+     read(cvalue,*) starttype
+  else
+     call ESMF_LogWrite('mom_cap:start_type unset - using input.nml for restart option', &
+	  ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
+
+  runtype = ""
+  if (trim(starttype) == trim('startup')) then
+     runtype = "initial"
+  else if (trim(starttype) == trim('continue') ) then
+     runtype = "continue"
+  else if (trim(starttype) == trim('branch')) then
+     runtype = "continue"
+  else if (len_trim(starttype) > 0) then
+     call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	  msg=subname//": unknown starttype - "//trim(starttype), &
+	  line=__LINE__, file=__FILE__, rcToReturn=rc)
+     return
+  endif
+
+  if (len_trim(runtype) > 0) then
+     call ESMF_LogWrite('mom_cap:startup = '//trim(runtype), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+  endif
+
+  restartfile = ""
+  if (runtype == "initial") then
+     ! startup (new run) - 'n' is needed below if we don't specify input_filename in input.nml
+     restartfile = "n"
+  else if (runtype == "continue") then ! hybrid or branch or continuos runs
+
+     ! optionally call into system-specific implementation to get restart file name
+     call ESMF_MethodExecute(gcomp, label="GetRestartFileToRead", &
+	  existflag=existflag, userRc=userRc, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if (existflag) then
+	call ESMF_LogWrite('mom_cap: called user GetRestartFileToRead', ESMF_LOGMSG_INFO, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return
+     endif
+
+     call NUOPC_CompAttributeGet(gcomp, name='RestartFileToRead', &
+	  value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     if (isPresent .and. isSet) then
+	restartfile = trim(cvalue)
+	call ESMF_LogWrite('mom_cap: RestartFileToRead = '//trim(restartfile), ESMF_LOGMSG_INFO, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return
+     else
+	call ESMF_LogWrite('mom_cap: restart requested, no RestartFileToRead attribute provided-will use input.nml',&
+	     ESMF_LOGMSG_WARNING, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return
+     endif
+
+  end if
+
+  ocean_public%is_ocean_pe = .true.
+  if (len_trim(restartfile) > 0) then
+     call ocean_model_init(ocean_public, ocean_state, Time, Time, input_restart_file=trim(restartfile))
+  else
+     call ocean_model_init(ocean_public, ocean_state, Time, Time)
+  endif
+
+  call ocean_model_init_sfc(ocean_state, ocean_public)
+
+  call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
+
+  allocate ( Ice_ocean_boundary% u_flux (isc:iec,jsc:jec),          &
+	     Ice_ocean_boundary% v_flux (isc:iec,jsc:jec),          &
+	     Ice_ocean_boundary% t_flux (isc:iec,jsc:jec),          &
+	     Ice_ocean_boundary% q_flux (isc:iec,jsc:jec),          &
+	     Ice_ocean_boundary% salt_flux (isc:iec,jsc:jec),       &
+	     Ice_ocean_boundary% lw_flux (isc:iec,jsc:jec),         &
+	     Ice_ocean_boundary% sw_flux_vis_dir (isc:iec,jsc:jec), &
+	     Ice_ocean_boundary% sw_flux_vis_dif (isc:iec,jsc:jec), &
+	     Ice_ocean_boundary% sw_flux_nir_dir (isc:iec,jsc:jec), &
+	     Ice_ocean_boundary% sw_flux_nir_dif (isc:iec,jsc:jec), &
+	     Ice_ocean_boundary% lprec (isc:iec,jsc:jec),           &
+	     Ice_ocean_boundary% fprec (isc:iec,jsc:jec),           &
+	     Ice_ocean_boundary% mi (isc:iec,jsc:jec),              &
+	     Ice_ocean_boundary% p (isc:iec,jsc:jec),               &
+	     Ice_ocean_boundary% runoff (isc:iec,jsc:jec),          &
+	     Ice_ocean_boundary% calving (isc:iec,jsc:jec),         &
+	     Ice_ocean_boundary% runoff_hflx (isc:iec,jsc:jec),     &
+	     Ice_ocean_boundary% calving_hflx (isc:iec,jsc:jec),    &
+	     Ice_ocean_boundary% rofl_flux (isc:iec,jsc:jec),       &
+	     Ice_ocean_boundary% rofi_flux (isc:iec,jsc:jec))
+
+  Ice_ocean_boundary%u_flux          = 0.0
+  Ice_ocean_boundary%v_flux          = 0.0
+  Ice_ocean_boundary%t_flux          = 0.0
+  Ice_ocean_boundary%q_flux          = 0.0
+  Ice_ocean_boundary%salt_flux       = 0.0
+  Ice_ocean_boundary%lw_flux         = 0.0
+  Ice_ocean_boundary%sw_flux_vis_dir = 0.0
+  Ice_ocean_boundary%sw_flux_vis_dif = 0.0
+  Ice_ocean_boundary%sw_flux_nir_dir = 0.0
+  Ice_ocean_boundary%sw_flux_nir_dif = 0.0
+  Ice_ocean_boundary%lprec           = 0.0
+  Ice_ocean_boundary%fprec           = 0.0
+  Ice_ocean_boundary%mi              = 0.0
+  Ice_ocean_boundary%p               = 0.0
+  Ice_ocean_boundary%runoff          = 0.0
+  Ice_ocean_boundary%calving         = 0.0
+  Ice_ocean_boundary%runoff_hflx     = 0.0
+  Ice_ocean_boundary%calving_hflx    = 0.0
+  Ice_ocean_boundary%rofl_flux       = 0.0
+  Ice_ocean_boundary%rofi_flux       = 0.0
+
+  ocean_internalstate%ptr%ocean_state_type_ptr => ocean_state
+  call ESMF_GridCompSetInternalState(gcomp, ocean_internalstate, rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  if (cesm_coupled) then
+     if (len_trim(scalar_field_name) > 0) then
+	call fld_list_add(fldsToOcn_num, fldsToOcn, trim(scalar_field_name), "will_provide")
+	call fld_list_add(fldsFrOcn_num, fldsFrOcn, trim(scalar_field_name), "will_provide")
+     endif
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_ustokes"                , "will provide")
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_vstokes"                , "will provide")
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_hstokes"                , "will provide")
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_melth"                , "will provide")
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"                , "will provide")
+    !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_fswpen"                 , "will provide")
+  else
+    !call fld_list_add(fldsToOcn_num, fldsToOcn, "mass_of_overlying_sea_ice" , "will provide")
+    !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_lev"                   , "will provide")
+  end if
+
+  !--------- import fields -------------
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_salt_rate"             , "will provide") ! from ice
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_zonal_moment_flx"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_merid_moment_flx"      , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_sensi_heat_flx"        , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_evap_rate"             , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_lw_flx"            , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dir_flx"    , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dif_flx"    , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dir_flx"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dif_flx"     , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_prec_rate"             , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_fprec_rate"            , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "inst_pres_height_surface"   , "will provide")
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"                  , "will provide") !-> liquid runoff
+  call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"                  , "will provide") !-> ice runoff
+  !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_water"          , "will provide")
+  !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_heat"           , "will provide")
+
+ !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_rate"           , "will provide")
+ !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_rate"          , "will provide")
+ !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_heat_flx"       , "will provide")
+ !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"      , "will provide")
+
+  !--------- export fields -------------
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocean_mask"                 , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_temperature"    , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "s_surf"                     , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_zonal"          , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_merid"          , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_zonal"    , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_merid"    , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "freezing_melting_potential" , "will provide")
+  call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"                 , "will provide")
+
+  do n = 1,fldsToOcn_num
+    call NUOPC_Advertise(importState, standardName=fldsToOcn(n)%stdname, name=fldsToOcn(n)%shortname, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &
       file=__FILE__)) &
       return  ! bail out
+  enddo
 
-    if (cesm_coupled) then
-       if (len_trim(scalar_field_name) > 0) then
-          call fld_list_add(fldsToOcn_num, fldsToOcn, trim(scalar_field_name), "will_provide")
-          call fld_list_add(fldsFrOcn_num, fldsFrOcn, trim(scalar_field_name), "will_provide")
-       endif
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_lamult"                 , "will provide")
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_ustokes"                , "will provide")
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_vstokes"                , "will provide")
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Sw_hstokes"                , "will provide")
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_melth"                , "will provide")
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "Fioi_meltw"                , "will provide")
-      !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_fswpen"                 , "will provide")
-    else
-      !call fld_list_add(fldsToOcn_num, fldsToOcn, "mass_of_overlying_sea_ice" , "will provide")
-      !call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_lev"                   , "will provide")
-    end if
+  do n = 1,fldsFrOcn_num
+    call NUOPC_Advertise(exportState, standardName=fldsFrOcn(n)%stdname, name=fldsFrOcn(n)%shortname, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+  enddo
 
-    !--------- import fields -------------
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_salt_rate"             , "will provide") ! from ice
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_zonal_moment_flx"      , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_merid_moment_flx"      , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_sensi_heat_flx"        , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_evap_rate"             , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_lw_flx"            , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dir_flx"    , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_vis_dif_flx"    , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dir_flx"     , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_net_sw_ir_dif_flx"     , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_prec_rate"             , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_fprec_rate"            , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "inst_pres_height_surface"   , "will provide")
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofl"                  , "will provide") !-> liquid runoff
-    call fld_list_add(fldsToOcn_num, fldsToOcn, "Foxx_rofi"                  , "will provide") !-> ice runoff
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_water"          , "will provide")
-    !call fld_list_add(fldsToOcn_num, fldsToOcn, "seaice_melt_heat"           , "will provide")
-
-   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_rate"           , "will provide")
-   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_rate"          , "will provide")
-   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_runoff_heat_flx"       , "will provide")
-   !call fld_list_add(fldsToOcn_num, fldsToOcn, "mean_calving_heat_flx"      , "will provide")
-
-    !--------- export fields -------------
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocean_mask"                 , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_temperature"    , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "s_surf"                     , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_zonal"          , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "ocn_current_merid"          , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_zonal"    , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "sea_surface_slope_merid"    , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "freezing_melting_potential" , "will provide")
-    call fld_list_add(fldsFrOcn_num, fldsFrOcn, "So_bldepth"                 , "will provide")
-
-    do n = 1,fldsToOcn_num
-      call NUOPC_Advertise(importState, standardName=fldsToOcn(n)%stdname, name=fldsToOcn(n)%shortname, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    enddo
-
-    do n = 1,fldsFrOcn_num
-      call NUOPC_Advertise(exportState, standardName=fldsFrOcn(n)%stdname, name=fldsFrOcn(n)%shortname, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    enddo
-
-  end subroutine InitializeAdvertise
+end subroutine InitializeAdvertise
 
 !===============================================================================
-  !> Called by NUOPC to realize import and export fields.  "Realizing" a field
-  !! means that its grid has been defined and an ESMF_Field object has been
-  !! created and put into the import or export State.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param importState an ESMF_State object for import fields
-  !! @param exportState an ESMF_State object for export fields
-  !! @param clock an ESMF_Clock object
-  !! @param rc return code
+!> Called by NUOPC to realize import and export fields.  "Realizing" a field
+!! means that its grid has been defined and an ESMF_Field object has been
+!! created and put into the import or export State.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param importState an ESMF_State object for import fields
+!! @param exportState an ESMF_State object for export fields
+!! @param clock an ESMF_Clock object
+!! @param rc return code
 
-  subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
-    type(ESMF_GridComp)  :: gcomp
-    type(ESMF_State)     :: importState, exportState
-    type(ESMF_Clock)     :: clock
-    integer, intent(out) :: rc
+subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+  type(ESMF_GridComp)  :: gcomp
+  type(ESMF_State)     :: importState, exportState
+  type(ESMF_Clock)     :: clock
+  integer, intent(out) :: rc
 
-    ! Local Variables
-    type(ESMF_VM)                              :: vm
-    type(ESMF_Grid)                            :: gridIn, gridOut
-    type(ESMF_Mesh)                            :: Emesh, EmeshTemp
-    type(ESMF_DeLayout)                        :: delayout
-    type(ESMF_Distgrid)                        :: Distgrid
-    type(ESMF_DistGridConnection), allocatable :: connectionList(:)
-    type(ESMF_StateItem_Flag)                  :: itemFlag
-    type (ocean_public_type),      pointer     :: ocean_public   => NULL()
-    type (ocean_state_type),       pointer     :: ocean_state => NULL()
-    type(ice_ocean_boundary_type), pointer     :: Ice_ocean_boundary => NULL()
-    type(ocean_grid_type)        , pointer     :: ocean_grid
-    type(ocean_internalstate_wrapper)          :: ocean_internalstate
-    integer                                    :: npet, ntiles
-    integer                                    :: nxg, nyg, cnt
-    integer                                    :: isc,iec,jsc,jec
-    integer, allocatable                       :: xb(:),xe(:),yb(:),ye(:),pe(:)
-    integer, allocatable                       :: deBlockList(:,:,:)
-    integer, allocatable                       :: petMap(:)
-    integer, allocatable                       :: deLabelList(:)
-    integer, allocatable                       :: indexList(:)
-    integer                                    :: ioff, joff
-    integer                                    :: i, j, n, i1, j1, n1, jlast
-    integer                                    :: lbnd1,ubnd1,lbnd2,ubnd2
-    integer                                    :: lbnd3,ubnd3,lbnd4,ubnd4
-    integer                                    :: nblocks_tot
-    logical                                    :: found
-    integer(ESMF_KIND_I4), pointer             :: dataPtr_mask(:,:)
-    real(ESMF_KIND_R8), pointer                :: dataPtr_area(:,:)
-    real(ESMF_KIND_R8), pointer                :: dataPtr_xcen(:,:)
-    real(ESMF_KIND_R8), pointer                :: dataPtr_ycen(:,:)
-    real(ESMF_KIND_R8), pointer                :: dataPtr_xcor(:,:)
-    real(ESMF_KIND_R8), pointer                :: dataPtr_ycor(:,:)
-    integer                                    :: mpicom
-    integer                                    :: localPet
-    integer                                    :: lsize
-    integer                                    :: ig,jg, ni,nj,k
-    integer, allocatable                       :: gindex(:) ! global index space
-    character(len=128)                         :: fldname
-    character(len=256)                         :: cvalue
-    character(len=*), parameter                :: subname='(mom_cap:InitializeRealize)'
-    !--------------------------------
+  ! Local Variables
+  type(ESMF_VM)                              :: vm
+  type(ESMF_Grid)                            :: gridIn, gridOut
+  type(ESMF_Mesh)                            :: Emesh, EmeshTemp
+  type(ESMF_DeLayout)                        :: delayout
+  type(ESMF_Distgrid)                        :: Distgrid
+  type(ESMF_DistGridConnection), allocatable :: connectionList(:)
+  type(ESMF_StateItem_Flag)                  :: itemFlag
+  type (ocean_public_type),      pointer     :: ocean_public   => NULL()
+  type (ocean_state_type),       pointer     :: ocean_state => NULL()
+  type(ice_ocean_boundary_type), pointer     :: Ice_ocean_boundary => NULL()
+  type(ocean_grid_type)        , pointer     :: ocean_grid
+  type(ocean_internalstate_wrapper)          :: ocean_internalstate
+  integer                                    :: npet, ntiles
+  integer                                    :: nxg, nyg, cnt
+  integer                                    :: isc,iec,jsc,jec
+  integer, allocatable                       :: xb(:),xe(:),yb(:),ye(:),pe(:)
+  integer, allocatable                       :: deBlockList(:,:,:)
+  integer, allocatable                       :: petMap(:)
+  integer, allocatable                       :: deLabelList(:)
+  integer, allocatable                       :: indexList(:)
+  integer                                    :: ioff, joff
+  integer                                    :: i, j, n, i1, j1, n1, jlast
+  integer                                    :: lbnd1,ubnd1,lbnd2,ubnd2
+  integer                                    :: lbnd3,ubnd3,lbnd4,ubnd4
+  integer                                    :: nblocks_tot
+  logical                                    :: found
+  integer(ESMF_KIND_I4), pointer             :: dataPtr_mask(:,:)
+  real(ESMF_KIND_R8), pointer                :: dataPtr_area(:,:)
+  real(ESMF_KIND_R8), pointer                :: dataPtr_xcen(:,:)
+  real(ESMF_KIND_R8), pointer                :: dataPtr_ycen(:,:)
+  real(ESMF_KIND_R8), pointer                :: dataPtr_xcor(:,:)
+  real(ESMF_KIND_R8), pointer                :: dataPtr_ycor(:,:)
+  integer                                    :: mpicom
+  integer                                    :: localPet
+  integer                                    :: lsize
+  integer                                    :: ig,jg, ni,nj,k
+  integer, allocatable                       :: gindex(:) ! global index space
+  character(len=128)                         :: fldname
+  character(len=256)                         :: cvalue
+  character(len=*), parameter                :: subname='(mom_cap:InitializeRealize)'
+  !--------------------------------
 
-    rc = ESMF_SUCCESS
+  rc = ESMF_SUCCESS
 
-    call shr_file_setLogUnit (logunit)
+  call shr_file_setLogUnit (logunit)
 
-    !----------------------------------------------------------------------------
-    ! Get pointers to ocean internal state
-    !----------------------------------------------------------------------------
+  !----------------------------------------------------------------------------
+  ! Get pointers to ocean internal state
+  !----------------------------------------------------------------------------
 
-    call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
+  ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
+  ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
+
+  !----------------------------------------------------------------------------
+  ! Get mpi information
+  !----------------------------------------------------------------------------
+
+  call ESMF_VMGetCurrent(vm, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_VMGet(vm, petCount=npet, mpiCommunicator=mpicom, localPet=localPet, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  !---------------------------------
+  ! global mom grid size
+  !---------------------------------
+
+  call mpp_get_global_domain(ocean_public%domain, xsize=nxg, ysize=nyg)
+  write(tmpstr,'(a,2i6)') subname//' nxg,nyg = ',nxg,nyg
+  call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  !---------------------------------
+  ! number of tiles per PET, assumed to be 1, and number of pes (tiles) total
+  !---------------------------------
+
+  ntiles=mpp_get_ntile_count(ocean_public%domain) ! this is tiles on this pe
+  if (ntiles /= 1) then
+    rc = ESMF_FAILURE
+    call ESMF_LogWrite(subname//' ntiles must be 1', ESMF_LOGMSG_ERROR, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+	 line=__LINE__, &
+	 file=__FILE__)) &
+	 return
+  endif
+  ntiles=mpp_get_domain_npes(ocean_public%domain)
+  write(tmpstr,'(a,1i6)') subname//' ntiles = ',ntiles
+  call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-    Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
-    ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
-    ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
+  !---------------------------------
+  ! get start and end indices of each tile and their PET
+  !---------------------------------
 
-    !----------------------------------------------------------------------------
-    ! Get mpi information
-    !----------------------------------------------------------------------------
+  allocate(xb(ntiles),xe(ntiles),yb(ntiles),ye(ntiles),pe(ntiles))
+  call mpp_get_compute_domains(ocean_public%domain, xbegin=xb, xend=xe, ybegin=yb, yend=ye)
+  call mpp_get_pelist(ocean_public%domain, pe)
+  if (debug > 0) then
+     do n = 1,ntiles
+	write(tmpstr,'(a,6i6)') subname//' tiles ',n,pe(n),xb(n),xe(n),yb(n),ye(n)
+	call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return
+     enddo
+  end if
 
-    call ESMF_VMGetCurrent(vm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  !---------------------------------
+  ! Create either a grid or a mesh
+  !---------------------------------
 
-    call ESMF_VMGet(vm, petCount=npet, mpiCommunicator=mpicom, localPet=localPet, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+   !Get the ocean grid and sizes of global and computational domains
+   call get_ocean_grid(ocean_state, ocean_grid)
 
-    !---------------------------------
-    ! global mom grid size
-    !---------------------------------
+  if (geomtype == ESMF_GEOMTYPE_MESH) then
 
-    call mpp_get_global_domain(ocean_public%domain, xsize=nxg, ysize=nyg)
-    write(tmpstr,'(a,2i6)') subname//' nxg,nyg = ',nxg,nyg
-    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     !---------------------------------
+     ! Create a MOM6 mesh
+     !---------------------------------
 
-    !---------------------------------
-    ! number of tiles per PET, assumed to be 1, and number of pes (tiles) total
-    !---------------------------------
+     call get_global_grid_size(ocean_grid, ni, nj)
+     lsize = ( ocean_grid%iec - ocean_grid%isc + 1 ) * ( ocean_grid%jec - ocean_grid%jsc + 1 )
 
-    ntiles=mpp_get_ntile_count(ocean_public%domain) ! this is tiles on this pe
-    if (ntiles /= 1) then
-      rc = ESMF_FAILURE
-      call ESMF_LogWrite(subname//' ntiles must be 1', ESMF_LOGMSG_ERROR, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-           line=__LINE__, &
-           file=__FILE__)) &
-           return
-    endif
-    ntiles=mpp_get_domain_npes(ocean_public%domain)
-    write(tmpstr,'(a,1i6)') subname//' ntiles = ',ntiles
-    call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+     ! Create the global index space for the computational domain
+     allocate(gindex(lsize))
+     k = 0
+     do j = ocean_grid%jsc, ocean_grid%jec
+	jg = j + ocean_grid%jdg_offset
+	do i = ocean_grid%isc, ocean_grid%iec
+	   ig = i + ocean_grid%idg_offset
+	   k = k + 1 ! Increment position within gindex
+	   gindex(k) = ni * (jg - 1) + ig
+	enddo
+     enddo
 
-    !---------------------------------
-    ! get start and end indices of each tile and their PET
-    !---------------------------------
+     DistGrid = ESMF_DistGridCreate(arbSeqIndexList=gindex, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
 
-    allocate(xb(ntiles),xe(ntiles),yb(ntiles),ye(ntiles),pe(ntiles))
-    call mpp_get_compute_domains(ocean_public%domain, xbegin=xb, xend=xe, ybegin=yb, yend=ye)
-    call mpp_get_pelist(ocean_public%domain, pe)
-    if (debug > 0) then
-       do n = 1,ntiles
-          write(tmpstr,'(a,6i6)') subname//' tiles ',n,pe(n),xb(n),xe(n),yb(n),ye(n)
-          call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return
-       enddo
-    end if
+     ! read in the mesh
+     call NUOPC_CompAttributeGet(gcomp, name='mesh_ocn', value=cvalue, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
 
-    !---------------------------------
-    ! Create either a grid or a mesh
-    !---------------------------------
+     EMeshTemp = ESMF_MeshCreate(filename=trim(cvalue), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     if (localPet == 0) then
+	write(logunit,*)'mesh file for mom6 domain is ',trim(cvalue)
+     end if
 
-     !Get the ocean grid and sizes of global and computational domains
-     call get_ocean_grid(ocean_state, ocean_grid)
+     ! recreate the mesh using the above distGrid
+     EMesh = ESMF_MeshCreate(EMeshTemp, elementDistgrid=Distgrid, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
 
-    if (geomtype == ESMF_GEOMTYPE_MESH) then
+     ! realize the import and export fields using the mesh
+     call MOM_RealizeFields(importState, fldsToOcn_num, fldsToOcn, "Ocn import", mesh=Emesh, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       !---------------------------------
-       ! Create a MOM6 mesh
-       !---------------------------------
+     call MOM_RealizeFields(exportState, fldsFrOcn_num, fldsFrOcn, "Ocn export", mesh=Emesh, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       call get_global_grid_size(ocean_grid, ni, nj)
-       lsize = ( ocean_grid%iec - ocean_grid%isc + 1 ) * ( ocean_grid%jec - ocean_grid%jsc + 1 )
+  else if (geomtype == ESMF_GEOMTYPE_GRID) then
 
-       ! Create the global index space for the computational domain
-       allocate(gindex(lsize))
-       k = 0
-       do j = ocean_grid%jsc, ocean_grid%jec
-          jg = j + ocean_grid%jdg_offset
-          do i = ocean_grid%isc, ocean_grid%iec
-             ig = i + ocean_grid%idg_offset
-             k = k + 1 ! Increment position within gindex
-             gindex(k) = ni * (jg - 1) + ig
-          enddo
-       enddo
+     !---------------------------------
+     ! create a MOM6 grid
+     !---------------------------------
 
-       DistGrid = ESMF_DistGridCreate(arbSeqIndexList=gindex, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
+     ! generate delayout and dist_grid
 
-       ! read in the mesh
-       call NUOPC_CompAttributeGet(gcomp, name='mesh_ocn', value=cvalue, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
+     allocate(deBlockList(2,2,ntiles))
+     allocate(petMap(ntiles))
+     allocate(deLabelList(ntiles))
 
-       EMeshTemp = ESMF_MeshCreate(filename=trim(cvalue), fileformat=ESMF_FILEFORMAT_ESMFMESH, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       if (localPet == 0) then
-          write(logunit,*)'mesh file for mom6 domain is ',trim(cvalue)
-       end if
+     do n = 1, ntiles
+	deLabelList(n) = n
+	deBlockList(1,1,n) = xb(n)
+	deBlockList(1,2,n) = xe(n)
+	deBlockList(2,1,n) = yb(n)
+	deBlockList(2,2,n) = ye(n)
+	petMap(n) = pe(n)
+	! write(tmpstr,'(a,3i8)') subname//' iglo = ',n,deBlockList(1,1,n),deBlockList(1,2,n)
+	! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+	! write(tmpstr,'(a,3i8)') subname//' jglo = ',n,deBlockList(2,1,n),deBlockList(2,2,n)
+	! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+	! write(tmpstr,'(a,2i8)') subname//' pe  = ',n,petMap(n)
+	! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+	!--- assume a tile with starting index of 1 has an equivalent wraparound tile on the other side
+     enddo
 
-       ! recreate the mesh using the above distGrid
-       EMesh = ESMF_MeshCreate(EMeshTemp, elementDistgrid=Distgrid, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
+     delayout = ESMF_DELayoutCreate(petMap, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       ! realize the import and export fields using the mesh
-       call MOM_RealizeFields(importState, fldsToOcn_num, fldsToOcn, "Ocn import", mesh=Emesh, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     ! rsd this assumes tripole grid, but sometimes in CESM a bipole
+     ! grid is used -- need to introduce conditional logic here
 
-       call MOM_RealizeFields(exportState, fldsFrOcn_num, fldsFrOcn, "Ocn export", mesh=Emesh, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     allocate(connectionList(2))
 
-    else if (geomtype == ESMF_GEOMTYPE_GRID) then
+     ! bipolar boundary condition at top row: nyg
+     call ESMF_DistGridConnectionSet(connectionList(1), tileIndexA=1, &
+	  tileIndexB=1, positionVector=(/nxg+1, 2*nyg+1/), &
+	  orientationVector=(/-1, -2/), rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       !---------------------------------
-       ! create a MOM6 grid
-       !---------------------------------
+     ! periodic boundary condition along first dimension
+     call ESMF_DistGridConnectionSet(connectionList(2), tileIndexA=1, &
+	  tileIndexB=1, positionVector=(/nxg, 0/), rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       ! generate delayout and dist_grid
+     distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/nxg,nyg/), &
+	  !        indexflag = ESMF_INDEX_DELOCAL, &
+	  deBlockList=deBlockList, &
+	  !        deLabelList=deLabelList, &
+	  delayout=delayout, &
+	  connectionList=connectionList, &
+	  rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       allocate(deBlockList(2,2,ntiles))
-       allocate(petMap(ntiles))
-       allocate(deLabelList(ntiles))
+     deallocate(xb,xe,yb,ye,pe)
+     deallocate(connectionList)
+     deallocate(deLabelList)
+     deallocate(deBlockList)
+     deallocate(petMap)
 
-       do n = 1, ntiles
-          deLabelList(n) = n
-          deBlockList(1,1,n) = xb(n)
-          deBlockList(1,2,n) = xe(n)
-          deBlockList(2,1,n) = yb(n)
-          deBlockList(2,2,n) = ye(n)
-          petMap(n) = pe(n)
-          ! write(tmpstr,'(a,3i8)') subname//' iglo = ',n,deBlockList(1,1,n),deBlockList(1,2,n)
-          ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-          ! write(tmpstr,'(a,3i8)') subname//' jglo = ',n,deBlockList(2,1,n),deBlockList(2,2,n)
-          ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-          ! write(tmpstr,'(a,2i8)') subname//' pe  = ',n,petMap(n)
-          ! call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-          !--- assume a tile with starting index of 1 has an equivalent wraparound tile on the other side
-       enddo
+     call ESMF_DistGridGet(distgrid=distgrid, localDE=0, elementCount=cnt, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     allocate(indexList(cnt))
+     write(tmpstr,'(a,i8)') subname//' distgrid cnt= ',cnt
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call ESMF_DistGridGet(distgrid=distgrid, localDE=0, seqIndexList=indexList, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     write(tmpstr,'(a,4i8)') subname//' distgrid list= ',&
+	  indexList(1),indexList(cnt),minval(indexList), maxval(indexList)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     deallocate(IndexList)
 
-       delayout = ESMF_DELayoutCreate(petMap, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     ! create grid
 
-       ! rsd this assumes tripole grid, but sometimes in CESM a bipole
-       ! grid is used -- need to introduce conditional logic here
+     gridIn = ESMF_GridCreate(distgrid=distgrid, &
+	  gridEdgeLWidth=(/0,0/), gridEdgeUWidth=(/0,1/), &
+	  coordSys = ESMF_COORDSYS_SPH_DEG, &
+	  rc = rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       allocate(connectionList(2))
+     call ESMF_GridAddCoord(gridIn, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     call ESMF_GridAddCoord(gridIn, staggerLoc=ESMF_STAGGERLOC_CORNER, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     call ESMF_GridAddItem(gridIn, itemFlag=ESMF_GRIDITEM_MASK, itemTypeKind=ESMF_TYPEKIND_I4, &
+	  staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       ! bipolar boundary condition at top row: nyg
-       call ESMF_DistGridConnectionSet(connectionList(1), tileIndexA=1, &
-            tileIndexB=1, positionVector=(/nxg+1, 2*nyg+1/), &
-            orientationVector=(/-1, -2/), rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     ! Attach area to the Grid optionally. By default the cell areas are computed.
+     if(grid_attach_area) then
+	call ESMF_GridAddItem(gridIn, itemFlag=ESMF_GRIDITEM_AREA, itemTypeKind=ESMF_TYPEKIND_R8, &
+	     staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+     endif
 
-       ! periodic boundary condition along first dimension
-       call ESMF_DistGridConnectionSet(connectionList(2), tileIndexA=1, &
-            tileIndexB=1, positionVector=(/nxg, 0/), rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     call ESMF_GridGetCoord(gridIn, coordDim=1, &
+	  staggerloc=ESMF_STAGGERLOC_CENTER, &
+	  farrayPtr=dataPtr_xcen, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     call ESMF_GridGetCoord(gridIn, coordDim=2, &
+	  staggerloc=ESMF_STAGGERLOC_CENTER, &
+	  farrayPtr=dataPtr_ycen, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       distgrid = ESMF_DistGridCreate(minIndex=(/1,1/), maxIndex=(/nxg,nyg/), &
-            !        indexflag = ESMF_INDEX_DELOCAL, &
-            deBlockList=deBlockList, &
-            !        deLabelList=deLabelList, &
-            delayout=delayout, &
-            connectionList=connectionList, &
-            rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     call ESMF_GridGetCoord(gridIn, coordDim=1, &
+	  staggerloc=ESMF_STAGGERLOC_CORNER, &
+	  farrayPtr=dataPtr_xcor, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     call ESMF_GridGetCoord(gridIn, coordDim=2, &
+	  staggerloc=ESMF_STAGGERLOC_CORNER, &
+	  farrayPtr=dataPtr_ycor, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-       deallocate(xb,xe,yb,ye,pe)
-       deallocate(connectionList)
-       deallocate(deLabelList)
-       deallocate(deBlockList)
-       deallocate(petMap)
+     call ESMF_GridGetItem(gridIn, itemflag=ESMF_GRIDITEM_MASK, &
+	  staggerloc=ESMF_STAGGERLOC_CENTER, &
+	  farrayPtr=dataPtr_mask, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if(grid_attach_area) then
+	call ESMF_GridGetItem(gridIn, itemflag=ESMF_GRIDITEM_AREA, &
+	     staggerloc=ESMF_STAGGERLOC_CENTER, &
+	     farrayPtr=dataPtr_area, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+     endif
 
-       call ESMF_DistGridGet(distgrid=distgrid, localDE=0, elementCount=cnt, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       allocate(indexList(cnt))
-       write(tmpstr,'(a,i8)') subname//' distgrid cnt= ',cnt
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call ESMF_DistGridGet(distgrid=distgrid, localDE=0, seqIndexList=indexList, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       write(tmpstr,'(a,4i8)') subname//' distgrid list= ',&
-            indexList(1),indexList(cnt),minval(indexList), maxval(indexList)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       deallocate(IndexList)
+     ! load up area, mask, center and corner values
+     ! area, mask, and centers should be same size in mom and esmf grid
+     ! corner points may not be, need to offset corner points by 1 in i and j
+     ! retrieve these values directly from ocean_grid, which contains halo
+     ! values for j=0 and wrap-around in i. on tripole seam, decomposition
+     ! domains are 1 larger in j; to load corner values need to loop one extra row
 
-       ! create grid
+     call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
 
-       gridIn = ESMF_GridCreate(distgrid=distgrid, &
-            gridEdgeLWidth=(/0,0/), gridEdgeUWidth=(/0,1/), &
-            coordSys = ESMF_COORDSYS_SPH_DEG, &
-            rc = rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     lbnd1 = lbound(dataPtr_mask,1)
+     ubnd1 = ubound(dataPtr_mask,1)
+     lbnd2 = lbound(dataPtr_mask,2)
+     ubnd2 = ubound(dataPtr_mask,2)
 
-       call ESMF_GridAddCoord(gridIn, staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       call ESMF_GridAddCoord(gridIn, staggerLoc=ESMF_STAGGERLOC_CORNER, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       call ESMF_GridAddItem(gridIn, itemFlag=ESMF_GRIDITEM_MASK, itemTypeKind=ESMF_TYPEKIND_I4, &
-            staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     lbnd3 = lbound(dataPtr_xcor,1)
+     ubnd3 = ubound(dataPtr_xcor,1)
+     lbnd4 = lbound(dataPtr_xcor,2)
+     ubnd4 = ubound(dataPtr_xcor,2)
 
-       ! Attach area to the Grid optionally. By default the cell areas are computed.
-       if(grid_attach_area) then
-          call ESMF_GridAddItem(gridIn, itemFlag=ESMF_GRIDITEM_AREA, itemTypeKind=ESMF_TYPEKIND_R8, &
-               staggerLoc=ESMF_STAGGERLOC_CENTER, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-       endif
+     write(tmpstr,*) subname//' iscjsc = ',isc,iec,jsc,jec
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
 
-       call ESMF_GridGetCoord(gridIn, coordDim=1, &
-            staggerloc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=dataPtr_xcen, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       call ESMF_GridGetCoord(gridIn, coordDim=2, &
-            staggerloc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=dataPtr_ycen, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     write(tmpstr,*) subname//' lbub12 = ',lbnd1,ubnd1,lbnd2,ubnd2
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
 
-       call ESMF_GridGetCoord(gridIn, coordDim=1, &
-            staggerloc=ESMF_STAGGERLOC_CORNER, &
-            farrayPtr=dataPtr_xcor, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       call ESMF_GridGetCoord(gridIn, coordDim=2, &
-            staggerloc=ESMF_STAGGERLOC_CORNER, &
-            farrayPtr=dataPtr_ycor, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
+     write(tmpstr,*) subname//' lbub34 = ',lbnd3,ubnd3,lbnd4,ubnd4
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
 
-       call ESMF_GridGetItem(gridIn, itemflag=ESMF_GRIDITEM_MASK, &
-            staggerloc=ESMF_STAGGERLOC_CENTER, &
-            farrayPtr=dataPtr_mask, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if(grid_attach_area) then
-          call ESMF_GridGetItem(gridIn, itemflag=ESMF_GRIDITEM_AREA, &
-               staggerloc=ESMF_STAGGERLOC_CENTER, &
-               farrayPtr=dataPtr_area, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-       endif
+     if (iec-isc /= ubnd1-lbnd1 .or. jec-jsc /= ubnd2-lbnd2) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=SUBNAME//": fld and grid do not have the same size.", &
+	     line=__LINE__, file=__FILE__, rcToReturn=rc)
+	return
+     endif
 
-       ! load up area, mask, center and corner values
-       ! area, mask, and centers should be same size in mom and esmf grid
-       ! corner points may not be, need to offset corner points by 1 in i and j
-       ! retrieve these values directly from ocean_grid, which contains halo
-       ! values for j=0 and wrap-around in i. on tripole seam, decomposition
-       ! domains are 1 larger in j; to load corner values need to loop one extra row
-
-       call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
-
-       lbnd1 = lbound(dataPtr_mask,1)
-       ubnd1 = ubound(dataPtr_mask,1)
-       lbnd2 = lbound(dataPtr_mask,2)
-       ubnd2 = ubound(dataPtr_mask,2)
-
-       lbnd3 = lbound(dataPtr_xcor,1)
-       ubnd3 = ubound(dataPtr_xcor,1)
-       lbnd4 = lbound(dataPtr_xcor,2)
-       ubnd4 = ubound(dataPtr_xcor,2)
-
-       write(tmpstr,*) subname//' iscjsc = ',isc,iec,jsc,jec
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       write(tmpstr,*) subname//' lbub12 = ',lbnd1,ubnd1,lbnd2,ubnd2
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       write(tmpstr,*) subname//' lbub34 = ',lbnd3,ubnd3,lbnd4,ubnd4
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       if (iec-isc /= ubnd1-lbnd1 .or. jec-jsc /= ubnd2-lbnd2) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=SUBNAME//": fld and grid do not have the same size.", &
-               line=__LINE__, file=__FILE__, rcToReturn=rc)
-          return
-       endif
-
-       do j = jsc, jec
-         j1 = j + lbnd2 - jsc
-         jg = j + ocean_grid%jsc - jsc
-         do i = isc, iec
-           i1 = i + lbnd1 - isc
-           ig = i + ocean_grid%isc - isc
-           dataPtr_mask(i1,j1)  = ocean_grid%mask2dT(ig,jg)
-           dataPtr_xcen(i1,j1)  = ocean_grid%geolonT(ig,jg)
-           dataPtr_ycen(i1,j1)  = ocean_grid%geolatT(ig,jg)
-           if(grid_attach_area) then
-            dataPtr_area(i1,j1)  = ocean_grid%areaT(ig,jg)
-           end if
-         end do
+     do j = jsc, jec
+       j1 = j + lbnd2 - jsc
+       jg = j + ocean_grid%jsc - jsc
+       do i = isc, iec
+	 i1 = i + lbnd1 - isc
+	 ig = i + ocean_grid%isc - isc
+	 dataPtr_mask(i1,j1)  = ocean_grid%mask2dT(ig,jg)
+	 dataPtr_xcen(i1,j1)  = ocean_grid%geolonT(ig,jg)
+	 dataPtr_ycen(i1,j1)  = ocean_grid%geolatT(ig,jg)
+	 if(grid_attach_area) then
+	  dataPtr_area(i1,j1)  = ocean_grid%areaT(ig,jg)
+	 end if
        end do
+     end do
 
-                     jlast = jec
-       if(jec == nyg)jlast = jec+1
+		   jlast = jec
+     if(jec == nyg)jlast = jec+1
 
-       do j = jsc, jlast
-         j1 = j + lbnd4 - jsc
-         jg = j + ocean_grid%jsc - jsc - 1
-         do i = isc, iec
-           i1 = i + lbnd3 - isc
-           ig = i + ocean_grid%isc - isc - 1
-           dataPtr_xcor(i1,j1)  = ocean_grid%geolonBu(ig,jg)
-           dataPtr_ycor(i1,j1)  = ocean_grid%geolatBu(ig,jg)
-         end do
+     do j = jsc, jlast
+       j1 = j + lbnd4 - jsc
+       jg = j + ocean_grid%jsc - jsc - 1
+       do i = isc, iec
+	 i1 = i + lbnd3 - isc
+	 ig = i + ocean_grid%isc - isc - 1
+	 dataPtr_xcor(i1,j1)  = ocean_grid%geolonBu(ig,jg)
+	 dataPtr_ycor(i1,j1)  = ocean_grid%geolatBu(ig,jg)
        end do
-
-       write(tmpstr,*) subname//' mask = ',minval(dataPtr_mask),maxval(dataPtr_mask)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       if(grid_attach_area) then
-          write(tmpstr,*) subname//' area = ',minval(dataPtr_area),maxval(dataPtr_area)
-          call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-       endif
-
-       write(tmpstr,*) subname//' xcen = ',minval(dataPtr_xcen),maxval(dataPtr_xcen)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       write(tmpstr,*) subname//' ycen = ',minval(dataPtr_ycen),maxval(dataPtr_ycen)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       write(tmpstr,*) subname//' xcor = ',minval(dataPtr_xcor),maxval(dataPtr_xcor)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       write(tmpstr,*) subname//' ycor = ',minval(dataPtr_ycor),maxval(dataPtr_ycor)
-       call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
-
-       gridOut = gridIn ! for now out same as in
-
-       call MOM_RealizeFields(importState, fldsToOcn_num, fldsToOcn, "Ocn import", grid=gridIn, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       call MOM_RealizeFields(exportState, fldsFrOcn_num, fldsFrOcn, "Ocn export", grid=gridOut, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-    end if
-
-    !---------------------------------
-    ! set scalar data in export state
-    !---------------------------------
-
-    if (len_trim(scalar_field_name) > 0) then
-       call State_SetScalar(dble(nxg),scalar_field_idx_grid_nx, exportState, localPet, &
-            scalar_field_name, scalar_field_count, rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       call State_SetScalar(dble(nyg),scalar_field_idx_grid_ny, exportState, localPet, &
-            scalar_field_name, scalar_field_count, rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-    endif
-
-    !---------------------------------
-    ! Set module variable geomtype in mom_cap_methods
-    !---------------------------------
-    call mom_set_geomtype(geomtype)
-
-    !---------------------------------
-    ! write out diagnostics
-    !---------------------------------
-
-    !call NUOPC_Write(exportState, fileNamePrefix='post_realize_field_ocn_export_', &
-    !     timeslice=1, relaxedFlag=.true., rc=rc)
-    !if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-    !     line=__LINE__, &
-    !     file=__FILE__)) &
-    !     return  ! bail out
-
-  end subroutine InitializeRealize
-
-  !===============================================================================
-
-  subroutine DataInitialize(gcomp, rc)
-    type(ESMF_GridComp)  :: gcomp
-    integer, intent(out) :: rc
-
-    ! local variables
-    type(ESMF_Clock)                       :: clock
-    type(ESMF_State)                       :: importState, exportState
-    type (ocean_public_type),      pointer :: ocean_public       => NULL()
-    type (ocean_state_type),       pointer :: ocean_state        => NULL()
-    type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
-    type(ocean_internalstate_wrapper)      :: ocean_internalstate
-    type(ocean_grid_type), pointer         :: ocean_grid
-    character(240)                         :: msgString
-    integer                                :: fieldCount, n
-    type(ESMF_Field)                       :: field
-    character(len=64),allocatable          :: fieldNameList(:)
-    character(len=*),parameter  :: subname='(mom_cap:DataInitialize)'
-    !--------------------------------
-
-    ! query the Component for its clock, importState and exportState
-    call ESMF_GridCompGet(gcomp, clock=clock, importState=importState, exportState=exportState, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
-    ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
-    ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
-    call get_ocean_grid(ocean_state, ocean_grid)
-
-    if (cesm_coupled) then
-       call mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-    end if
-
-    call ESMF_StateGet(exportState, itemCount=fieldCount, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    allocate(fieldNameList(fieldCount))
-    call ESMF_StateGet(exportState, itemNameList=fieldNameList, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    do n=1, fieldCount
-      call ESMF_StateGet(exportState, itemName=fieldNameList(n), field=field, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-
-      call NUOPC_SetAttribute(field, name="Updated", value="true", rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    end do
-    deallocate(fieldNameList)
-
-    ! check whether all Fields in the exportState are "Updated"
-    if (NUOPC_IsUpdated(exportState)) then
-      call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="true", rc=rc)
-
-      call ESMF_LogWrite("MOM6 - Initialize-Data-Dependency SATISFIED!!!", ESMF_LOGMSG_INFO, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    end if
-
-    if(write_diagnostics) then
-      call NUOPC_Write(exportState, fileNamePrefix='field_init_ocn_export_', &
-        timeslice=import_slice, relaxedFlag=.true., rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-    endif
-
-  end subroutine DataInitialize
-
-  !===============================================================================
-
-  !> Called by NUOPC to advance the model a single timestep.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param rc return code
-  subroutine ModelAdvance(gcomp, rc)
-    type(ESMF_GridComp)                    :: gcomp
-    integer, intent(out)                   :: rc
-
-    ! local variables
-    integer                                :: userRc
-    logical                                :: existflag, isPresent, isSet
-    type(ESMF_Clock)                       :: clock
-    type(ESMF_Alarm)                       :: alarm
-    type(ESMF_State)                       :: importState, exportState
-    type(ESMF_Time)                        :: currTime
-    type(ESMF_TimeInterval)                :: timeStep
-    type(ESMF_Time)                        :: startTime
-    type(ESMF_TimeInterval)                :: time_elapsed
-    integer(ESMF_KIND_I8)                  :: n_interval, time_elapsed_sec
-    character(len=64)                      :: timestamp
-    type (ocean_public_type),      pointer :: ocean_public       => NULL()
-    type (ocean_state_type),       pointer :: ocean_state        => NULL()
-    type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
-    type(ocean_internalstate_wrapper)      :: ocean_internalstate
-    type(ocean_grid_type)        , pointer :: ocean_grid
-    type(time_type)                        :: Time
-    type(time_type)                        :: Time_step_coupled
-    type(time_type)                        :: Time_restart_current
-    integer                                :: dth, dtm, dts
-    integer                                :: nc
-    type(ESMF_Time)                        :: MyTime
-    integer                                :: seconds, day, year, month, hour, minute
-    character(ESMF_MAXSTR)                 :: restartname, cvalue
-    character(240)                         :: msgString
-    character(len=*),parameter             :: subname='(mom_cap:ModelAdvance)'
-    !--------------------------------
-
-    rc = ESMF_SUCCESS
-    if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
-
-    call shr_file_setLogUnit (logunit)
-
-    ! query the Component for its clock, importState and exportState
-    call ESMF_GridCompGet(gcomp, clock=clock, importState=importState, &
-      exportState=exportState, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
-    ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
-    ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
-
-    ! HERE THE MODEL ADVANCES: currTime -> currTime + timeStep
-
-    call ESMF_ClockPrint(clock, options="currTime", &
-      preString="------>Advancing OCN from: ", unit=msgString, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_LogWrite(subname//trim(msgString), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockGet(clock, startTime=startTime, currTime=currTime, &
-      timeStep=timeStep, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_TimePrint(currTime + timeStep, &
-      preString="--------------------------------> to: ", &
-      unit=msgString, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    Time = esmf2fms_time(currTime)
-    Time_step_coupled = esmf2fms_time(timeStep)
-
-    !---------------
-    ! Write diagnostics for import
-    !---------------
-
-    if(write_diagnostics) then
-      call NUOPC_Write(importState, fileNamePrefix='field_ocn_import_', &
-        timeslice=import_slice, relaxedFlag=.true., rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-      import_slice = import_slice + 1
-    endif
-
-    !---------------
-    ! Get ocean grid
-    !---------------
-
-    call get_ocean_grid(ocean_state, ocean_grid)
-
-    !---------------
-    ! Import data
-    !---------------
-
-    call shr_file_setLogUnit (logunit)
-
-    if (cesm_coupled) then
-       call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype=runtype, rc=rc)
-    else
-       call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, rc=rc)
-    end if
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-
-    !---------------
-    ! Update MOM6
-    !---------------
-
-    if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM update_ocean_model: ")
-    call update_ocean_model(Ice_ocean_boundary, ocean_state, ocean_public, Time, Time_step_coupled)
-    if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM update_ocean_model: ")
-
-    !---------------
-    ! Export Data
-    !---------------
-
-    call mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-
-    call shr_file_setLogUnit (logunit)
-
-    !---------------
-    ! If restart alarm is ringing - write restart file
-    !---------------
-
-    call ESMF_ClockGetAlarm(clock, alarmname='alarm_restart', alarm=alarm, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-
-    if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       call ESMF_AlarmRingerOff(alarm, rc=rc )
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! call into system specific method to get desired restart filename
-       restartname = ""
-       call ESMF_MethodExecute(gcomp, label="GetRestartFileToWrite", &
-            existflag=existflag, userRc=userRc, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if (existflag) then
-          call ESMF_LogWrite("mom_cap: called user GetRestartFileToWrite method", ESMF_LOGMSG_INFO, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          call NUOPC_CompAttributeGet(gcomp, name='RestartFileToWrite', &
-               isPresent=isPresent, isSet=isSet, value=cvalue, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          if (isPresent .and. isSet) then
-             restartname = trim(cvalue)
-             call ESMF_LogWrite("mom_cap: User RestartFileToWrite: "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-                  line=__LINE__, &
-                  file=__FILE__)) &
-                  return  ! bail out
-          endif
-       endif
-
-       if (len_trim(restartname) == 0) then
-          ! none provided, so use a default restart filename
-          call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, &
-               h=hour, m=minute, s=seconds, rc=rc )
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') &
-               "ocn", year, month, day, hour, minute, seconds
-          call ESMF_LogWrite("mom_cap: Using default restart filename:  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-       endif
-
-       ! TODO: address if this requirement is being met for the DA group
-       ! Optionally write restart files when currTime-startTime is integer multiples of restart_interval
-       ! if (restart_interval > 0 ) then
-       !   time_elapsed = currTime - startTime
-       !   call ESMF_TimeIntervalGet(time_elapsed, s_i8=time_elapsed_sec, rc=rc)
-       !   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-       !     line=__LINE__, &
-       !     file=__FILE__)) &
-       !     return  ! bail out
-       !   n_interval = time_elapsed_sec / restart_interval
-       !   if ((n_interval .gt. 0) .and. (n_interval*restart_interval == time_elapsed_sec)) then
-       !       time_restart_current = esmf2fms_time(currTime)
-       !       timestamp = date_to_string(time_restart_current)
-       !       call ESMF_LogWrite("MOM: Writing restart at "//trim(timestamp), ESMF_LOGMSG_INFO, rc=rc)
-       !       write(*,*) 'calling ocean_model_restart'
-       !       call ocean_model_restart(ocean_state, timestamp)
-       !   endif
-       ! endif
-
-       ! write restart file(s)
-       call ocean_model_restart(ocean_state, restartname=restartname)
-
-       if (is_root_pe()) then
-          write(logunit,*) subname//' writing restart file ',trim(restartname)
-       end if
-    endif
-
-    !---------------
-    ! Write diagnostics
-    !---------------
-
-    if (write_diagnostics) then
-       call NUOPC_Write(exportState, fileNamePrefix='field_ocn_export_', &
-            timeslice=export_slice, relaxedFlag=.true., rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       export_slice = export_slice + 1
-    endif
-
-    if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
-
-  end subroutine ModelAdvance
-
-  !===============================================================================
-
-  subroutine ModelSetRunClock(gcomp, rc)
-    type(ESMF_GridComp)  :: gcomp
-    integer, intent(out) :: rc
-
-    ! local variables
-    type(ESMF_Clock)         :: mclock, dclock
-    type(ESMF_Time)          :: mcurrtime, dcurrtime
-    type(ESMF_Time)          :: mstoptime
-    type(ESMF_TimeInterval)  :: mtimestep, dtimestep
-    character(len=128)       :: mtimestring, dtimestring
-    character(len=256)       :: cvalue
-    character(len=256)       :: restart_option ! Restart option units
-    integer                  :: restart_n      ! Number until restart interval
-    integer                  :: restart_ymd    ! Restart date (YYYYMMDD)
-    type(ESMF_ALARM)         :: restart_alarm
-    logical                  :: isPresent, isSet
-    logical                  :: first_time = .true.
-    character(len=*),parameter :: subname='mom_cap:(ModelSetRunClock) '
-    !--------------------------------
-
-    rc = ESMF_SUCCESS
-
-    ! query the Component for its clock, importState and exportState
-    call NUOPC_ModelGet(gcomp, driverClock=dclock, modelClock=mclock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    !--------------------------------
-    ! check that the current time in the model and driver are the same
-    !--------------------------------
-
-    if (mcurrtime /= dcurrtime) then
-      call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-
-      call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-        line=__LINE__, &
-        file=__FILE__)) &
-        return  ! bail out
-
-      call ESMF_LogSetError(ESMF_RC_VAL_WRONG, &
-           msg=subname//": ERROR in time consistency: "//trim(dtimestring)//" != "//trim(mtimestring),  &
-           line=__LINE__, file=__FILE__, rcToReturn=rc)
-      return
-    endif
-
-    !--------------------------------
-    ! force model clock currtime and timestep to match driver and set stoptime
-    !--------------------------------
-
-    mstoptime = mcurrtime + dtimestep
-
-    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    if (first_time) then
-       !--------------------------------
-       ! set restart alarm
-       !--------------------------------
-
-       ! defaults
-       restart_n = 0
-       restart_ymd = 0
-
-       call NUOPC_CompAttributeGet(gcomp, name="restart_option", isPresent=isPresent, &
-            isSet=isSet, value=restart_option, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       if (isPresent .and. isSet) then
-          call NUOPC_CompAttributeGet(gcomp,  name="restart_n", value=cvalue, &
-               isPresent=isPresent, isSet=isSet, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          if (isPresent .and. isSet) then
-             read(cvalue,*) restart_n
-          endif
-          call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, &
-               isPresent=isPresent, isSet=isSet, rc=rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
-          if (isPresent .and. isSet) then
-             read(cvalue,*) restart_ymd
-          endif
-       else
-          restart_option = "none"
-       endif
-
-       call AlarmInit(mclock, &
-            alarm   = restart_alarm,         &
-            option  = trim(restart_option),  &
-            opt_n   = restart_n,             &
-            opt_ymd = restart_ymd,           &
-            RefTime = mcurrTime,             &
-            alarmname = 'alarm_restart', rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       call ESMF_AlarmSet(restart_alarm, clock=mclock, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       first_time = .false.
-
-       call ESMF_LogWrite(subname//" Set restart option = "//restart_option, &
-            ESMF_LOGMSG_INFO, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-    end if
-
-    !--------------------------------
-    ! Advance model clock to trigger alarms then reset model clock back to currtime
-    !--------------------------------
-
-    call ESMF_ClockAdvance(mclock,rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-  end subroutine ModelSetRunClock
-
-
-  !===============================================================================
-
-  !> Called by NUOPC at the end of the run to clean up.
-  !!
-  !! @param gcomp an ESMF_GridComp object
-  !! @param rc return code
-  subroutine ocean_model_finalize(gcomp, rc)
-
-    ! input arguments
-    type(ESMF_GridComp)  :: gcomp
-    integer, intent(out) :: rc
-
-    ! local variables
-    type (ocean_public_type),      pointer :: ocean_public
-    type (ocean_state_type),       pointer :: ocean_state
-    type(ocean_internalstate_wrapper)      :: ocean_internalstate
-    type(TIME_TYPE)                        :: Time
-    type(ESMF_Clock)                       :: clock
-    type(ESMF_Time)                        :: currTime
-    character(len=64)                      :: timestamp
-    character(len=*),parameter  :: subname='(mom_cap:ocean_model_finalize)'
-
-    write(*,*) 'MOM: --- finalize called ---'
-    rc = ESMF_SUCCESS
-
-    call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    ocean_public => ocean_internalstate%ptr%ocean_public_type_ptr
-    ocean_state  => ocean_internalstate%ptr%ocean_state_type_ptr
-
-    call NUOPC_ModelGet(gcomp, modelClock=clock, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-
-    call ESMF_ClockGet(clock, currTime=currTime, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    Time = esmf2fms_time(currTime)
-
-    if (cesm_coupled) then
-       call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.false.)
-    else
-       call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.true.)
-    end if
-    call field_manager_end()
-
-    call fms_io_exit()
-    call fms_end()
-
-    write(*,*) 'MOM: --- completed ---'
-
-  end subroutine ocean_model_finalize
+     end do
+
+     write(tmpstr,*) subname//' mask = ',minval(dataPtr_mask),maxval(dataPtr_mask)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
+     if(grid_attach_area) then
+	write(tmpstr,*) subname//' area = ',minval(dataPtr_area),maxval(dataPtr_area)
+	call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+     endif
+
+     write(tmpstr,*) subname//' xcen = ',minval(dataPtr_xcen),maxval(dataPtr_xcen)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
+     write(tmpstr,*) subname//' ycen = ',minval(dataPtr_ycen),maxval(dataPtr_ycen)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
+     write(tmpstr,*) subname//' xcor = ',minval(dataPtr_xcor),maxval(dataPtr_xcor)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
+     write(tmpstr,*) subname//' ycor = ',minval(dataPtr_ycor),maxval(dataPtr_ycor)
+     call ESMF_LogWrite(trim(tmpstr), ESMF_LOGMSG_INFO, rc=rc)
+
+     gridOut = gridIn ! for now out same as in
+
+     call MOM_RealizeFields(importState, fldsToOcn_num, fldsToOcn, "Ocn import", grid=gridIn, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+     call MOM_RealizeFields(exportState, fldsFrOcn_num, fldsFrOcn, "Ocn export", grid=gridOut, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+  end if
+
+  !---------------------------------
+  ! set scalar data in export state
+  !---------------------------------
+
+  if (len_trim(scalar_field_name) > 0) then
+     call State_SetScalar(dble(nxg),scalar_field_idx_grid_nx, exportState, localPet, &
+	  scalar_field_name, scalar_field_count, rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+     call State_SetScalar(dble(nyg),scalar_field_idx_grid_ny, exportState, localPet, &
+	  scalar_field_name, scalar_field_count, rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+  endif
+
+  !---------------------------------
+  ! Set module variable geomtype in mom_cap_methods
+  !---------------------------------
+  call mom_set_geomtype(geomtype)
+
+  !---------------------------------
+  ! write out diagnostics
+  !---------------------------------
+
+  !call NUOPC_Write(exportState, fileNamePrefix='post_realize_field_ocn_export_', &
+  !     timeslice=1, relaxedFlag=.true., rc=rc)
+  !if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+  !     line=__LINE__, &
+  !     file=__FILE__)) &
+  !     return  ! bail out
+
+end subroutine InitializeRealize
 
 !===============================================================================
 
-  subroutine State_SetScalar(value, scalar_id, State, mytask, scalar_name, scalar_count,  rc)
-    ! ----------------------------------------------
-    ! Set scalar data from State for a particular name
-    ! ----------------------------------------------
+subroutine DataInitialize(gcomp, rc)
+  type(ESMF_GridComp)  :: gcomp
+  integer, intent(out) :: rc
 
-    real(ESMF_KIND_R8),intent(in)     :: value
-    integer,           intent(in)     :: scalar_id
-    type(ESMF_State),  intent(inout)  :: State
-    integer,           intent(in)     :: mytask
-    character(len=*),  intent(in)     :: scalar_name
-    integer,           intent(in)     :: scalar_count
-    integer,           intent(inout)  :: rc
+  ! local variables
+  type(ESMF_Clock)                       :: clock
+  type(ESMF_State)                       :: importState, exportState
+  type (ocean_public_type),      pointer :: ocean_public       => NULL()
+  type (ocean_state_type),       pointer :: ocean_state        => NULL()
+  type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
+  type(ocean_internalstate_wrapper)      :: ocean_internalstate
+  type(ocean_grid_type), pointer         :: ocean_grid
+  character(240)                         :: msgString
+  integer                                :: fieldCount, n
+  type(ESMF_Field)                       :: field
+  character(len=64),allocatable          :: fieldNameList(:)
+  character(len=*),parameter  :: subname='(mom_cap:DataInitialize)'
+  !--------------------------------
 
-    ! local variables
-    type(ESMF_Field)                :: field
-    real(ESMF_KIND_R8), pointer     :: farrayptr(:,:)
-    character(len=*), parameter     :: subname='(mom_cap:State_SetScalar)'
-    !--------------------------------------------------------
+  ! query the Component for its clock, importState and exportState
+  call ESMF_GridCompGet(gcomp, clock=clock, importState=importState, exportState=exportState, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    rc = ESMF_SUCCESS
+  call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    call ESMF_StateGet(State, itemName=trim(scalar_name), field=field, rc=rc)
+  Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
+  ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
+  ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
+  call get_ocean_grid(ocean_state, ocean_grid)
+
+  if (cesm_coupled) then
+     call mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+  end if
+
+  call ESMF_StateGet(exportState, itemCount=fieldCount, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  allocate(fieldNameList(fieldCount))
+  call ESMF_StateGet(exportState, itemNameList=fieldNameList, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  do n=1, fieldCount
+    call ESMF_StateGet(exportState, itemName=fieldNameList(n), field=field, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call NUOPC_SetAttribute(field, name="Updated", value="true", rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+  end do
+  deallocate(fieldNameList)
+
+  ! check whether all Fields in the exportState are "Updated"
+  if (NUOPC_IsUpdated(exportState)) then
+    call NUOPC_CompAttributeSet(gcomp, name="InitializeDataComplete", value="true", rc=rc)
+
+    call ESMF_LogWrite("MOM6 - Initialize-Data-Dependency SATISFIED!!!", ESMF_LOGMSG_INFO, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+  end if
+
+  if(write_diagnostics) then
+    call NUOPC_Write(exportState, fileNamePrefix='field_init_ocn_export_', &
+      timeslice=import_slice, relaxedFlag=.true., rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+  endif
+
+end subroutine DataInitialize
+
+!===============================================================================
+
+!> Called by NUOPC to advance the model a single timestep.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param rc return code
+subroutine ModelAdvance(gcomp, rc)
+  type(ESMF_GridComp)                    :: gcomp
+  integer, intent(out)                   :: rc
+
+  ! local variables
+  integer                                :: userRc
+  logical                                :: existflag, isPresent, isSet
+  type(ESMF_Clock)                       :: clock
+  type(ESMF_Alarm)                       :: alarm
+  type(ESMF_State)                       :: importState, exportState
+  type(ESMF_Time)                        :: currTime
+  type(ESMF_TimeInterval)                :: timeStep
+  type(ESMF_Time)                        :: startTime
+  type(ESMF_TimeInterval)                :: time_elapsed
+  integer(ESMF_KIND_I8)                  :: n_interval, time_elapsed_sec
+  character(len=64)                      :: timestamp
+  type (ocean_public_type),      pointer :: ocean_public       => NULL()
+  type (ocean_state_type),       pointer :: ocean_state        => NULL()
+  type(ice_ocean_boundary_type), pointer :: Ice_ocean_boundary => NULL()
+  type(ocean_internalstate_wrapper)      :: ocean_internalstate
+  type(ocean_grid_type)        , pointer :: ocean_grid
+  type(time_type)                        :: Time
+  type(time_type)                        :: Time_step_coupled
+  type(time_type)                        :: Time_restart_current
+  integer                                :: dth, dtm, dts
+  integer                                :: nc
+  type(ESMF_Time)                        :: MyTime
+  integer                                :: seconds, day, year, month, hour, minute
+  character(ESMF_MAXSTR)                 :: restartname, cvalue
+  character(240)                         :: msgString
+  character(len=*),parameter             :: subname='(mom_cap:ModelAdvance)'
+  !--------------------------------
+
+  rc = ESMF_SUCCESS
+  if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM Model_ADVANCE: ")
+
+  call shr_file_setLogUnit (logunit)
+
+  ! query the Component for its clock, importState and exportState
+  call ESMF_GridCompGet(gcomp, clock=clock, importState=importState, &
+    exportState=exportState, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  Ice_ocean_boundary => ocean_internalstate%ptr%ice_ocean_boundary_type_ptr
+  ocean_public       => ocean_internalstate%ptr%ocean_public_type_ptr
+  ocean_state        => ocean_internalstate%ptr%ocean_state_type_ptr
+
+  ! HERE THE MODEL ADVANCES: currTime -> currTime + timeStep
+
+  call ESMF_ClockPrint(clock, options="currTime", &
+    preString="------>Advancing OCN from: ", unit=msgString, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call ESMF_LogWrite(subname//trim(msgString), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_ClockGet(clock, startTime=startTime, currTime=currTime, &
+    timeStep=timeStep, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_TimePrint(currTime + timeStep, &
+    preString="--------------------------------> to: ", &
+    unit=msgString, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  Time = esmf2fms_time(currTime)
+  Time_step_coupled = esmf2fms_time(timeStep)
+
+  !---------------
+  ! Write diagnostics for import
+  !---------------
+
+  if(write_diagnostics) then
+    call NUOPC_Write(importState, fileNamePrefix='field_ocn_import_', &
+      timeslice=import_slice, relaxedFlag=.true., rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+    import_slice = import_slice + 1
+  endif
+
+  !---------------
+  ! Get ocean grid
+  !---------------
+
+  call get_ocean_grid(ocean_state, ocean_grid)
+
+  !---------------
+  ! Import data
+  !---------------
+
+  call shr_file_setLogUnit (logunit)
+
+  if (cesm_coupled) then
+     call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype=runtype, rc=rc)
+  else
+     call mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, rc=rc)
+  end if
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  !---------------
+  ! Update MOM6
+  !---------------
+
+  if(profile_memory) call ESMF_VMLogMemInfo("Entering MOM update_ocean_model: ")
+  call update_ocean_model(Ice_ocean_boundary, ocean_state, ocean_public, Time, Time_step_coupled)
+  if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM update_ocean_model: ")
+
+  !---------------
+  ! Export Data
+  !---------------
+
+  call mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  call shr_file_setLogUnit (logunit)
+
+  !---------------
+  ! If restart alarm is ringing - write restart file
+  !---------------
+
+  call ESMF_ClockGetAlarm(clock, alarmname='alarm_restart', alarm=alarm, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  if (ESMF_AlarmIsRinging(alarm, rc=rc)) then
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+     call ESMF_AlarmRingerOff(alarm, rc=rc )
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+     ! call into system specific method to get desired restart filename
+     restartname = ""
+     call ESMF_MethodExecute(gcomp, label="GetRestartFileToWrite", &
+	  existflag=existflag, userRc=userRc, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg="Error executing user method to get restart filename", &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if (ESMF_LogFoundError(rcToCheck=userRc, msg="Error in method to get restart filename", &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if (existflag) then
+	call ESMF_LogWrite("mom_cap: called user GetRestartFileToWrite method", ESMF_LOGMSG_INFO, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	call NUOPC_CompAttributeGet(gcomp, name='RestartFileToWrite', &
+	     isPresent=isPresent, isSet=isSet, value=cvalue, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	if (isPresent .and. isSet) then
+	   restartname = trim(cvalue)
+	   call ESMF_LogWrite("mom_cap: User RestartFileToWrite: "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
+	   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+		line=__LINE__, &
+		file=__FILE__)) &
+		return  ! bail out
+	endif
+     endif
+
+     if (len_trim(restartname) == 0) then
+	! none provided, so use a default restart filename
+	call ESMF_ClockGetNextTime(clock, MyTime, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	call ESMF_TimeGet (MyTime, yy=year, mm=month, dd=day, &
+	     h=hour, m=minute, s=seconds, rc=rc )
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	write(restartname,'(A,".mom6.r.",I4.4,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2,"-",I2.2)') &
+	     "ocn", year, month, day, hour, minute, seconds
+	call ESMF_LogWrite("mom_cap: Using default restart filename:  "//trim(restartname), ESMF_LOGMSG_INFO, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+     endif
+
+     ! TODO: address if this requirement is being met for the DA group
+     ! Optionally write restart files when currTime-startTime is integer multiples of restart_interval
+     ! if (restart_interval > 0 ) then
+     !   time_elapsed = currTime - startTime
+     !   call ESMF_TimeIntervalGet(time_elapsed, s_i8=time_elapsed_sec, rc=rc)
+     !   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+     !     line=__LINE__, &
+     !     file=__FILE__)) &
+     !     return  ! bail out
+     !   n_interval = time_elapsed_sec / restart_interval
+     !   if ((n_interval .gt. 0) .and. (n_interval*restart_interval == time_elapsed_sec)) then
+     !       time_restart_current = esmf2fms_time(currTime)
+     !       timestamp = date_to_string(time_restart_current)
+     !       call ESMF_LogWrite("MOM: Writing restart at "//trim(timestamp), ESMF_LOGMSG_INFO, rc=rc)
+     !       write(*,*) 'calling ocean_model_restart'
+     !       call ocean_model_restart(ocean_state, timestamp)
+     !   endif
+     ! endif
+
+     ! write restart file(s)
+     call ocean_model_restart(ocean_state, restartname=restartname)
+
+     if (is_root_pe()) then
+	write(logunit,*) subname//' writing restart file ',trim(restartname)
+     end if
+  endif
+
+  !---------------
+  ! Write diagnostics
+  !---------------
+
+  if (write_diagnostics) then
+     call NUOPC_Write(exportState, fileNamePrefix='field_ocn_export_', &
+	  timeslice=export_slice, relaxedFlag=.true., rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     export_slice = export_slice + 1
+  endif
+
+  if(profile_memory) call ESMF_VMLogMemInfo("Leaving MOM Model_ADVANCE: ")
+
+end subroutine ModelAdvance
+
+!===============================================================================
+
+subroutine ModelSetRunClock(gcomp, rc)
+  type(ESMF_GridComp)  :: gcomp
+  integer, intent(out) :: rc
+
+  ! local variables
+  type(ESMF_Clock)         :: mclock, dclock
+  type(ESMF_Time)          :: mcurrtime, dcurrtime
+  type(ESMF_Time)          :: mstoptime
+  type(ESMF_TimeInterval)  :: mtimestep, dtimestep
+  character(len=128)       :: mtimestring, dtimestring
+  character(len=256)       :: cvalue
+  character(len=256)       :: restart_option ! Restart option units
+  integer                  :: restart_n      ! Number until restart interval
+  integer                  :: restart_ymd    ! Restart date (YYYYMMDD)
+  type(ESMF_ALARM)         :: restart_alarm
+  logical                  :: isPresent, isSet
+  logical                  :: first_time = .true.
+  character(len=*),parameter :: subname='mom_cap:(ModelSetRunClock) '
+  !--------------------------------
+
+  rc = ESMF_SUCCESS
+
+  ! query the Component for its clock, importState and exportState
+  call NUOPC_ModelGet(gcomp, driverClock=dclock, modelClock=mclock, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_ClockGet(dclock, currTime=dcurrtime, timeStep=dtimestep, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_ClockGet(mclock, currTime=mcurrtime, timeStep=mtimestep, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  !--------------------------------
+  ! check that the current time in the model and driver are the same
+  !--------------------------------
+
+  if (mcurrtime /= dcurrtime) then
+    call ESMF_TimeGet(dcurrtime, timeString=dtimestring, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call ESMF_TimeGet(mcurrtime, timeString=mtimestring, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    call ESMF_LogSetError(ESMF_RC_VAL_WRONG, &
+	 msg=subname//": ERROR in time consistency: "//trim(dtimestring)//" != "//trim(mtimestring),  &
+	 line=__LINE__, file=__FILE__, rcToReturn=rc)
+    return
+  endif
+
+  !--------------------------------
+  ! force model clock currtime and timestep to match driver and set stoptime
+  !--------------------------------
+
+  mstoptime = mcurrtime + dtimestep
+
+  call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  if (first_time) then
+     !--------------------------------
+     ! set restart alarm
+     !--------------------------------
+
+     ! defaults
+     restart_n = 0
+     restart_ymd = 0
+
+     call NUOPC_CompAttributeGet(gcomp, name="restart_option", isPresent=isPresent, &
+	  isSet=isSet, value=restart_option, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     if (isPresent .and. isSet) then
+	call NUOPC_CompAttributeGet(gcomp,  name="restart_n", value=cvalue, &
+	     isPresent=isPresent, isSet=isSet, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	if (isPresent .and. isSet) then
+	   read(cvalue,*) restart_n
+	endif
+	call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, &
+	     isPresent=isPresent, isSet=isSet, rc=rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+	if (isPresent .and. isSet) then
+	   read(cvalue,*) restart_ymd
+	endif
+     else
+	restart_option = "none"
+     endif
+
+     call AlarmInit(mclock, &
+	  alarm   = restart_alarm,         &
+	  option  = trim(restart_option),  &
+	  opt_n   = restart_n,             &
+	  opt_ymd = restart_ymd,           &
+	  RefTime = mcurrTime,             &
+	  alarmname = 'alarm_restart', rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+     call ESMF_AlarmSet(restart_alarm, clock=mclock, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     first_time = .false.
+
+     call ESMF_LogWrite(subname//" Set restart option = "//restart_option, &
+	  ESMF_LOGMSG_INFO, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+  end if
+
+  !--------------------------------
+  ! Advance model clock to trigger alarms then reset model clock back to currtime
+  !--------------------------------
+
+  call ESMF_ClockAdvance(mclock,rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_ClockSet(mclock, currTime=dcurrtime, timeStep=dtimestep, stopTime=mstoptime, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+end subroutine ModelSetRunClock
+
+
+!===============================================================================
+
+!> Called by NUOPC at the end of the run to clean up.
+!!
+!! @param gcomp an ESMF_GridComp object
+!! @param rc return code
+subroutine ocean_model_finalize(gcomp, rc)
+
+  ! input arguments
+  type(ESMF_GridComp)  :: gcomp
+  integer, intent(out) :: rc
+
+  ! local variables
+  type (ocean_public_type),      pointer :: ocean_public
+  type (ocean_state_type),       pointer :: ocean_state
+  type(ocean_internalstate_wrapper)      :: ocean_internalstate
+  type(TIME_TYPE)                        :: Time
+  type(ESMF_Clock)                       :: clock
+  type(ESMF_Time)                        :: currTime
+  character(len=64)                      :: timestamp
+  character(len=*),parameter  :: subname='(mom_cap:ocean_model_finalize)'
+
+  write(*,*) 'MOM: --- finalize called ---'
+  rc = ESMF_SUCCESS
+
+  call ESMF_GridCompGetInternalState(gcomp, ocean_internalstate, rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  ocean_public => ocean_internalstate%ptr%ocean_public_type_ptr
+  ocean_state  => ocean_internalstate%ptr%ocean_state_type_ptr
+
+  call NUOPC_ModelGet(gcomp, modelClock=clock, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_ClockGet(clock, currTime=currTime, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  Time = esmf2fms_time(currTime)
+
+  if (cesm_coupled) then
+     call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.false.)
+  else
+     call ocean_model_end(ocean_public, ocean_State, Time, write_restart=.true.)
+  end if
+  call field_manager_end()
+
+  call fms_io_exit()
+  call fms_end()
+
+  write(*,*) 'MOM: --- completed ---'
+
+end subroutine ocean_model_finalize
+
+!===============================================================================
+
+subroutine State_SetScalar(value, scalar_id, State, mytask, scalar_name, scalar_count,  rc)
+  ! ----------------------------------------------
+  ! Set scalar data from State for a particular name
+  ! ----------------------------------------------
+
+  real(ESMF_KIND_R8),intent(in)     :: value
+  integer,           intent(in)     :: scalar_id
+  type(ESMF_State),  intent(inout)  :: State
+  integer,           intent(in)     :: mytask
+  character(len=*),  intent(in)     :: scalar_name
+  integer,           intent(in)     :: scalar_count
+  integer,           intent(inout)  :: rc
+
+  ! local variables
+  type(ESMF_Field)                :: field
+  real(ESMF_KIND_R8), pointer     :: farrayptr(:,:)
+  character(len=*), parameter     :: subname='(mom_cap:State_SetScalar)'
+  !--------------------------------------------------------
+
+  rc = ESMF_SUCCESS
+
+  call ESMF_StateGet(State, itemName=trim(scalar_name), field=field, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
+
+  if (mytask == 0) then
+    call ESMF_FieldGet(field, farrayPtr=farrayptr, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
 
-    if (mytask == 0) then
-      call ESMF_FieldGet(field, farrayPtr=farrayptr, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, line=__LINE__, file=u_FILE_u)) return
-
-      if (scalar_id < 0 .or. scalar_id > scalar_count) then
-         call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-              msg=subname//": ERROR in scalar_id", &
-              line=__LINE__, file=__FILE__, rcToReturn=rc)
-         return
-      endif
-
-      farrayptr(scalar_id,1) = value
-    endif
-
-  end subroutine State_SetScalar
-
-!===============================================================================
-
-  subroutine MOM_RealizeFields(state, nfields, field_defs, tag, grid, mesh, rc)
-
-    ! input/output variables
-    type(ESMF_State)    , intent(inout)        :: state
-    integer             , intent(in)           :: nfields
-    type(fld_list_type) , intent(inout)        :: field_defs(:)
-    character(len=*)    , intent(in)           :: tag
-    type(ESMF_Grid)     , intent(in), optional :: grid
-    type(ESMF_Mesh)     , intent(in), optional :: mesh
-    integer             , intent(inout)        :: rc
-
-    ! local variables
-    integer                     :: i
-    type(ESMF_Field)            :: field
-    real(ESMF_KIND_R8), pointer :: fldptr1d(:)   ! for mesh
-    real(ESMF_KIND_R8), pointer :: fldptr2d(:,:) ! for grid
-    character(len=*),parameter  :: subname='(mom_cap:MOM_RealizeFields)'
-    !--------------------------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    do i = 1, nfields
-
-      if (NUOPC_IsConnected(state, fieldName=field_defs(i)%shortname)) then
-
-        if (field_defs(i)%shortname == scalar_field_name) then
-
-          call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is connected on root pe.", &
-            ESMF_LOGMSG_INFO, &
-            line=__LINE__, &
-            file=__FILE__, &
-            rc=rc)
-
-          call SetScalarField(field, rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-        else
-
-          call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is connected.", &
-            ESMF_LOGMSG_INFO, &
-            line=__LINE__, &
-            file=__FILE__, &
-            rc=rc)
-
-          if (present(grid)) then
-
-             field = ESMF_FieldCreate(grid, ESMF_TYPEKIND_R8, indexflag=ESMF_INDEX_DELOCAL, &
-                  name=field_defs(i)%shortname, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-                  line=__LINE__, &
-                  file=__FILE__)) &
-                  return  ! bail out
-
-             ! initialize fldptr to zero
-             call ESMF_FieldGet(field, farrayPtr=fldptr2d, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-                  line=__LINE__, &
-                  file=__FILE__)) &
-                  return  ! bail out
-             fldptr2d(:,:) = 0.0
-
-          else if (present(mesh)) then
-
-             field = ESMF_FieldCreate(mesh=mesh, typekind=ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, &
-                  name=field_defs(i)%shortname, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-                  line=__LINE__, &
-                  file=__FILE__)) &
-                  return  ! bail out
-
-             ! initialize fldptr to zero
-             call ESMF_FieldGet(field, farrayPtr=fldptr1d, rc=rc)
-             if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-                  line=__LINE__, &
-                  file=__FILE__)) &
-                  return  ! bail out
-             fldptr1d(:) = 0.0
-
-          end if
-
-        endif
-
-        ! Realize connected field
-        call NUOPC_Realize(state, field=field, rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, &
-          file=__FILE__)) &
-          return  ! bail out
-
-      else ! field is not connected
-
-        call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is not connected.", &
-          ESMF_LOGMSG_INFO, &
-          line=__LINE__, &
-          file=__FILE__, &
-          rc=rc)
-        ! remove a not connected Field from State
-        call ESMF_StateRemove(state, (/field_defs(i)%shortname/), rc=rc)
-        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-          line=__LINE__, &
-          file=__FILE__)) &
-          return  ! bail out
-
-      endif
-
-    enddo
-
-  contains  !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
-    subroutine SetScalarField(field, rc)
-
-      ! create a field with scalar data on the root pe
-      type(ESMF_Field), intent(inout)  :: field
-      integer,          intent(inout)  :: rc
-
-      ! local variables
-      type(ESMF_Distgrid) :: distgrid
-      type(ESMF_Grid)     :: grid
-      character(len=*), parameter :: subname='(mom_cap:SetScalarField)'
-
-      rc = ESMF_SUCCESS
-
-      ! create a DistGrid with a single index space element, which gets mapped onto DE 0.
-      distgrid = ESMF_DistGridCreate(minIndex=(/1/), maxIndex=(/1/), rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-           line=__LINE__, &
-           file=__FILE__)) &
-           return  ! bail out
-
-      grid = ESMF_GridCreate(distgrid, rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-           line=__LINE__, &
-           file=__FILE__)) &
-           return  ! bail out
-
-      ! num of scalar values
-      field = ESMF_FieldCreate(name=trim(scalar_field_name), grid=grid, typekind=ESMF_TYPEKIND_R8, &
-           ungriddedLBound=(/1/), ungriddedUBound=(/scalar_field_count/), gridToFieldMap=(/2/), rc=rc)
-      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-           line=__LINE__, &
-           file=__FILE__)) &
-           return  ! bail out
-
-    end subroutine SetScalarField
-
-  end subroutine MOM_RealizeFields
-
-!===============================================================================
-
-  subroutine fld_list_add(num, fldlist, stdname, transferOffer, shortname)
-    ! ----------------------------------------------
-    ! Set up a list of field information
-    ! ----------------------------------------------
-    integer,                    intent(inout) :: num
-    type(fld_list_type),        intent(inout) :: fldlist(:)
-    character(len=*),           intent(in)    :: stdname
-    character(len=*),           intent(in)    :: transferOffer
-    character(len=*), optional, intent(in)    :: shortname
-
-    ! local variables
-    integer :: rc
-    character(len=*), parameter :: subname='(mom_cap:fld_list_add)'
-
-    ! fill in the new entry
-    num = num + 1
-    if (num > fldsMax) then
-       call ESMF_LogSetError(ESMF_RC_VAL_OUTOFRANGE, &
-            msg=trim(subname)//": ERROR number of field exceeded fldsMax: "//trim(stdname), &
-            line=__LINE__, file=__FILE__, rcToReturn=rc)
+    if (scalar_id < 0 .or. scalar_id > scalar_count) then
+       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	    msg=subname//": ERROR in scalar_id", &
+	    line=__LINE__, file=__FILE__, rcToReturn=rc)
        return
     endif
 
-    fldlist(num)%stdname        = trim(stdname)
-    if (present(shortname)) then
-       fldlist(num)%shortname   = trim(shortname)
-    else
-       fldlist(num)%shortname   = trim(stdname)
-    endif
-    fldlist(num)%transferOffer  = trim(transferOffer)
+    farrayptr(scalar_id,1) = value
+  endif
 
-  end subroutine fld_list_add
+end subroutine State_SetScalar
+
+!===============================================================================
+
+subroutine MOM_RealizeFields(state, nfields, field_defs, tag, grid, mesh, rc)
+
+  ! input/output variables
+  type(ESMF_State)    , intent(inout)        :: state
+  integer             , intent(in)           :: nfields
+  type(fld_list_type) , intent(inout)        :: field_defs(:)
+  character(len=*)    , intent(in)           :: tag
+  type(ESMF_Grid)     , intent(in), optional :: grid
+  type(ESMF_Mesh)     , intent(in), optional :: mesh
+  integer             , intent(inout)        :: rc
+
+  ! local variables
+  integer                     :: i
+  type(ESMF_Field)            :: field
+  real(ESMF_KIND_R8), pointer :: fldptr1d(:)   ! for mesh
+  real(ESMF_KIND_R8), pointer :: fldptr2d(:,:) ! for grid
+  character(len=*),parameter  :: subname='(mom_cap:MOM_RealizeFields)'
+  !--------------------------------------------------------
+
+  rc = ESMF_SUCCESS
+
+  do i = 1, nfields
+
+    if (NUOPC_IsConnected(state, fieldName=field_defs(i)%shortname)) then
+
+      if (field_defs(i)%shortname == scalar_field_name) then
+
+	call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is connected on root pe.", &
+	  ESMF_LOGMSG_INFO, &
+	  line=__LINE__, &
+	  file=__FILE__, &
+	  rc=rc)
+
+	call SetScalarField(field, rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+
+      else
+
+	call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is connected.", &
+	  ESMF_LOGMSG_INFO, &
+	  line=__LINE__, &
+	  file=__FILE__, &
+	  rc=rc)
+
+	if (present(grid)) then
+
+	   field = ESMF_FieldCreate(grid, ESMF_TYPEKIND_R8, indexflag=ESMF_INDEX_DELOCAL, &
+		name=field_defs(i)%shortname, rc=rc)
+	   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+		line=__LINE__, &
+		file=__FILE__)) &
+		return  ! bail out
+
+	   ! initialize fldptr to zero
+	   call ESMF_FieldGet(field, farrayPtr=fldptr2d, rc=rc)
+	   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+		line=__LINE__, &
+		file=__FILE__)) &
+		return  ! bail out
+	   fldptr2d(:,:) = 0.0
+
+	else if (present(mesh)) then
+
+	   field = ESMF_FieldCreate(mesh=mesh, typekind=ESMF_TYPEKIND_R8, meshloc=ESMF_MESHLOC_ELEMENT, &
+		name=field_defs(i)%shortname, rc=rc)
+	   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+		line=__LINE__, &
+		file=__FILE__)) &
+		return  ! bail out
+
+	   ! initialize fldptr to zero
+	   call ESMF_FieldGet(field, farrayPtr=fldptr1d, rc=rc)
+	   if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+		line=__LINE__, &
+		file=__FILE__)) &
+		return  ! bail out
+	   fldptr1d(:) = 0.0
+
+	end if
+
+      endif
+
+      ! Realize connected field
+      call NUOPC_Realize(state, field=field, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	line=__LINE__, &
+	file=__FILE__)) &
+	return  ! bail out
+
+    else ! field is not connected
+
+      call ESMF_LogWrite(subname // tag // " Field "// trim(field_defs(i)%stdname) // " is not connected.", &
+	ESMF_LOGMSG_INFO, &
+	line=__LINE__, &
+	file=__FILE__, &
+	rc=rc)
+      ! remove a not connected Field from State
+      call ESMF_StateRemove(state, (/field_defs(i)%shortname/), rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	line=__LINE__, &
+	file=__FILE__)) &
+	return  ! bail out
+
+    endif
+
+  enddo
+
+contains  !- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  subroutine SetScalarField(field, rc)
+
+    ! create a field with scalar data on the root pe
+    type(ESMF_Field), intent(inout)  :: field
+    integer,          intent(inout)  :: rc
+
+    ! local variables
+    type(ESMF_Distgrid) :: distgrid
+    type(ESMF_Grid)     :: grid
+    character(len=*), parameter :: subname='(mom_cap:SetScalarField)'
+
+    rc = ESMF_SUCCESS
+
+    ! create a DistGrid with a single index space element, which gets mapped onto DE 0.
+    distgrid = ESMF_DistGridCreate(minIndex=(/1/), maxIndex=(/1/), rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	 line=__LINE__, &
+	 file=__FILE__)) &
+	 return  ! bail out
+
+    grid = ESMF_GridCreate(distgrid, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	 line=__LINE__, &
+	 file=__FILE__)) &
+	 return  ! bail out
+
+    ! num of scalar values
+    field = ESMF_FieldCreate(name=trim(scalar_field_name), grid=grid, typekind=ESMF_TYPEKIND_R8, &
+	 ungriddedLBound=(/1/), ungriddedUBound=(/scalar_field_count/), gridToFieldMap=(/2/), rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	 line=__LINE__, &
+	 file=__FILE__)) &
+	 return  ! bail out
+
+  end subroutine SetScalarField
+
+end subroutine MOM_RealizeFields
+
+!===============================================================================
+
+subroutine fld_list_add(num, fldlist, stdname, transferOffer, shortname)
+  ! ----------------------------------------------
+  ! Set up a list of field information
+  ! ----------------------------------------------
+  integer,                    intent(inout) :: num
+  type(fld_list_type),        intent(inout) :: fldlist(:)
+  character(len=*),           intent(in)    :: stdname
+  character(len=*),           intent(in)    :: transferOffer
+  character(len=*), optional, intent(in)    :: shortname
+
+  ! local variables
+  integer :: rc
+  character(len=*), parameter :: subname='(mom_cap:fld_list_add)'
+
+  ! fill in the new entry
+  num = num + 1
+  if (num > fldsMax) then
+     call ESMF_LogSetError(ESMF_RC_VAL_OUTOFRANGE, &
+	  msg=trim(subname)//": ERROR number of field exceeded fldsMax: "//trim(stdname), &
+	  line=__LINE__, file=__FILE__, rcToReturn=rc)
+     return
+  endif
+
+  fldlist(num)%stdname        = trim(stdname)
+  if (present(shortname)) then
+     fldlist(num)%shortname   = trim(shortname)
+  else
+     fldlist(num)%shortname   = trim(stdname)
+  endif
+  fldlist(num)%transferOffer  = trim(transferOffer)
+
+end subroutine fld_list_add
 
 !=======================================================================
 
 #ifndef CESMCOUPLED
-  subroutine shr_file_setLogUnit(nunit)
-    integer, intent(in) :: nunit
-    ! do nothing for this stub - its just here to replace
-    ! having cppdefs in the main program
-  end subroutine shr_file_setLogUnit
+subroutine shr_file_setLogUnit(nunit)
+  integer, intent(in) :: nunit
+  ! do nothing for this stub - its just here to replace
+  ! having cppdefs in the main program
+end subroutine shr_file_setLogUnit
 
-  subroutine shr_file_getLogUnit(nunit)
-    integer, intent(in) :: nunit
-    ! do nothing for this stub - its just here to replace
-    ! having cppdefs in the main program
-  end subroutine shr_file_getLogUnit
+subroutine shr_file_getLogUnit(nunit)
+  integer, intent(in) :: nunit
+  ! do nothing for this stub - its just here to replace
+  ! having cppdefs in the main program
+end subroutine shr_file_getLogUnit
 #endif
 
 end module mom_cap_mod

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -1,6 +1,5 @@
+!> Contains import/export methods for both NEMS and CMEPS.
 module mom_cap_methods
-
-! Cap import/export methods for both NEMS and CMEPS
 
 use ESMF,                only: ESMF_Clock, ESMF_ClockGet, ESMF_time, ESMF_TimeGet
 use ESMF,                only: ESMF_TimeInterval, ESMF_TimeIntervalGet
@@ -33,33 +32,31 @@ public :: mom_export
 private :: State_getImport
 private :: State_setExport
 
+!> Get field pointer
 interface State_GetFldPtr
    module procedure State_GetFldPtr_1d
    module procedure State_GetFldPtr_2d
 end interface
 
-integer                  :: import_cnt = 0
-type(ESMF_GeomType_Flag) :: geomtype
+integer                  :: import_cnt = 0!< used to skip using the import state
+                                          !! at the first count for cesm
+type(ESMF_GeomType_Flag) :: geomtype      !< SMF type describing type of
+                                          !! geometry (mesh or grid)
 
-!===============================================================================
 contains
-!===============================================================================
 
+!> Sets module variable geometry type
 subroutine mom_set_geomtype(geomtype_in)
-  ! Set module variable geomtype
-
-  type(ESMF_GeomType_Flag), intent(in)    :: geomtype_in     !< mesh or grid
+  type(ESMF_GeomType_Flag), intent(in)    :: geomtype_in !< ESMF type describing type of
+                                                         !! geometry (mesh or grid)
 
   geomtype = geomtype_in
 
 end subroutine mom_set_geomtype
 
-!===============================================================================
-
 !> This function has a few purposes:
 !! (1) it imports surface fluxes using data from the mediator; and
 !! (2) it can apply restoring in SST and SSS.
-
 subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype, rc)
 
   ! Input/output variables
@@ -68,7 +65,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
   type(ice_ocean_boundary_type) , intent(inout) :: ice_ocean_boundary !< Ocean boundary forcing
   character(len=*), optional    , intent(in)    :: runtype            !< For cesm only, type of run
-  integer                       , intent(inout) :: rc
+  integer                       , intent(inout) :: rc                 !< Error handler
 
   ! Local Variables
   integer                         :: i, j, ig, jg, n
@@ -79,8 +76,6 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   real(ESMF_KIND_R8), allocatable :: tauy(:,:)
   character(len=*)  , parameter   :: subname = '(mom_import)'
 
-  !-----------------------------------------------------------------------
-
   rc = ESMF_SUCCESS
 
   ! -------
@@ -90,9 +85,9 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   if (present(runtype)) then
      import_cnt = import_cnt + 1
      if ((trim(runtype) == 'initial' .and. import_cnt <= 2)) then
-	do_import = .false. ! This will skip the first time import information is given
+        do_import = .false. ! This will skip the first time import information is given
      else
-	do_import = .true.
+        do_import = .true.
      end if
   else
      do_import = .true.
@@ -106,61 +101,61 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
      ! surface height pressure
      !----
      call state_getimport(importState, 'inst_pres_height_surface', &
-	  isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
      !----
      ! near-IR, direct shortwave  (W/m2)
      !----
      call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
-	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
      !----
      ! near-IR, diffuse shortwave  (W/m2)
      !----
      call state_getimport(importState, 'mean_net_sw_ir_dif_flx', &
-	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dif, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dif, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
      !----
      ! visible, direct shortwave  (W/m2)
      !----
      call state_getimport(importState, 'mean_net_sw_vis_dir_flx', &
-	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dir, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dir, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
 
      !----
      ! visible, diffuse shortwave (W/m2)
      !----
      call state_getimport(importState, 'mean_net_sw_vis_dif_flx', &
-	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dif, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dif, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
      ! -------
      ! Net longwave radiation (W/m2)
      ! -------
      call state_getimport(importState, 'mean_net_lw_flx',  &
-	  isc, iec, jsc, jec, ice_ocean_boundary%lw_flux, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%lw_flux, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
      !----
      ! zonal and meridional surface stress
@@ -170,14 +165,15 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
 
      call state_getimport(importState, 'mean_zonal_moment_flx', isc, iec, jsc, jec, taux, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
      call state_getimport(importState, 'mean_merid_moment_flx', isc, iec, jsc, jec, tauy, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
+
 
      ! rotate taux and tauy from true zonal/meridional to local coordinates
      do j = jsc, jec
@@ -335,17 +331,15 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
 
      ice_ocean_boundary%mi(:,:) = 0._ESMF_KIND_R8
      call state_getimport(importState, 'mass_of_overlying_ice',  &
-	  isc, iec, jsc, jec, ice_ocean_boundary%mi, rc=rc)
+          isc, iec, jsc, jec, ice_ocean_boundary%mi, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-	  line=__LINE__, &
-	  file=__FILE__)) &
-	  return  ! bail out
+         line=__LINE__, &
+         file=__FILE__)) &
+         return  ! bail out
 
   end if
 
 end subroutine mom_import
-
-!===============================================================================
 
 !> Maps outgoing ocean data to ESMF State
 subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc)
@@ -353,10 +347,10 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
   ! Input/output variables
   type(ocean_public_type) , intent(in)    :: ocean_public !< Ocean surface state
   type(ocean_grid_type)   , intent(in)    :: ocean_grid   !< Ocean model grid
-  type(ocean_state_type)  , pointer       :: ocean_state
+  type(ocean_state_type)  , pointer       :: ocean_state  !< Ocean state
   type(ESMF_State)        , intent(inout) :: exportState  !< outgoing data
-  type(ESMF_Clock)        , intent(in)    :: clock
-  integer                 , intent(inout) :: rc
+  type(ESMF_Clock)        , intent(in)    :: clock        !< ESMF clock
+  integer                 , intent(inout) :: rc           !< Error handler
 
   ! Local variables
   integer                         :: i, j, ig, jg         ! indices
@@ -380,7 +374,6 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
   real(ESMF_KIND_R8), allocatable :: dhdx(:,:), dhdy(:,:)
   real(ESMF_KIND_R8), allocatable :: dhdx_rot(:,:), dhdy_rot(:,:)
   character(len=*)  , parameter   :: subname = '(mom_export)'
-  !-----------------------------------------------------------------------
 
   rc = ESMF_SUCCESS
 
@@ -660,13 +653,12 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 
 end subroutine mom_export
 
-!===============================================================================
-
+!> Get field pointer 1D
 subroutine State_GetFldPtr_1d(State, fldname, fldptr, rc)
-  type(ESMF_State)            , intent(in)  :: State
-  character(len=*)            , intent(in)  :: fldname
-  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:)
-  integer, optional           , intent(out) :: rc
+  type(ESMF_State)            , intent(in)  :: State    !< ESMF state
+  character(len=*)            , intent(in)  :: fldname  !< Field name
+  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:)!< Pointer to the 1D field
+  integer, optional           , intent(out) :: rc       !< Error handler
 
   ! local variables
   type(ESMF_Field) :: lfield
@@ -688,13 +680,12 @@ subroutine State_GetFldPtr_1d(State, fldname, fldptr, rc)
 
 end subroutine State_GetFldPtr_1d
 
-!===============================================================================
-
+!> Get field pointer 2D
 subroutine State_GetFldPtr_2d(State, fldname, fldptr, rc)
-  type(ESMF_State)            , intent(in)  :: State
-  character(len=*)            , intent(in)  :: fldname
-  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:,:)
-  integer, optional           , intent(out) :: rc
+  type(ESMF_State)            , intent(in)  :: State      !< ESMF state
+  character(len=*)            , intent(in)  :: fldname    !< Field name
+  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:,:)!< Pointer to the 2D field
+  integer, optional           , intent(out) :: rc         !< Error handler
 
   ! local variables
   type(ESMF_Field) :: lfield
@@ -716,24 +707,21 @@ subroutine State_GetFldPtr_2d(State, fldname, fldptr, rc)
 
 end subroutine State_GetFldPtr_2d
 
-!===============================================================================
-
+!> Map import state field to output array
 subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, rc)
-
-  ! ----------------------------------------------
-  ! Map import state field to output array
-  ! ----------------------------------------------
-
-  ! input/output variables
-  type(ESMF_State)    , intent(in)    :: state
-  character(len=*)    , intent(in)    :: fldname
-  integer             , intent(in)    :: isc
-  integer             , intent(in)    :: iec
-  integer             , intent(in)    :: jsc
-  integer             , intent(in)    :: jec
-  real (ESMF_KIND_R8) , intent(inout) :: output(isc:iec,jsc:jec)
-  logical, optional   , intent(in)    :: do_sum
-  integer             , intent(out)   :: rc
+  type(ESMF_State)    , intent(in)    :: state   !< ESMF state
+  character(len=*)    , intent(in)    :: fldname !< Field name
+  integer             , intent(in)    :: isc     !< The start i-index of cell centers within
+                                                 !! the computational domain
+  integer             , intent(in)    :: iec     !< The end i-index of cell centers within the
+                                                 !! computational domain
+  integer             , intent(in)    :: jsc     !< The start j-index of cell centers within
+                                                 !! the computational domain
+  integer             , intent(in)    :: jec     !< The end j-index of cell centers within
+                                                 !! the computational domain
+  real (ESMF_KIND_R8) , intent(inout) :: output(isc:iec,jsc:jec)!< Output 2D array
+  logical, optional   , intent(in)    :: do_sum  !< If true, sums the data
+  integer             , intent(out)   :: rc      !< Error handler
 
   ! local variables
   type(ESMF_StateItem_Flag)     :: itemFlag
@@ -800,24 +788,21 @@ subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, r
 
 end subroutine State_GetImport
 
-!===============================================================================
-
+!> Map input array to export state
 subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid, rc)
-
-  ! ----------------------------------------------
-  ! Map input array to export state
-  ! ----------------------------------------------
-
-  ! input/output variables
-  type(ESMF_State)      , intent(inout) :: state
-  character(len=*)      , intent(in)    :: fldname
-  integer               , intent(in)    :: isc
-  integer               , intent(in)    :: iec
-  integer               , intent(in)    :: jsc
-  integer               , intent(in)    :: jec
-  real (ESMF_KIND_R8)   , intent(in)    :: input(isc:iec,jsc:jec)
-  type(ocean_grid_type) , intent(in)    :: ocean_grid
-  integer               , intent(out)   :: rc
+  type(ESMF_State)      , intent(inout) :: state   !< ESMF state
+  character(len=*)      , intent(in)    :: fldname !< Field name
+  integer             , intent(in)      :: isc     !< The start i-index of cell centers within
+                                                   !! the computational domain
+  integer             , intent(in)      :: iec     !< The end i-index of cell centers within the
+                                                   !! computational domain
+  integer             , intent(in)      :: jsc     !< The start j-index of cell centers within
+                                                   !! the computational domain
+  integer             , intent(in)      :: jec     !< The end j-index of cell centers within
+                                                   !! the computational domain
+  real (ESMF_KIND_R8)   , intent(in)    :: input(isc:iec,jsc:jec)!< Input 2D array
+  type(ocean_grid_type) , intent(in)    :: ocean_grid !< Ocean horizontal grid
+  integer               , intent(out)   :: rc         !< Error handler
 
   ! local variables
   type(ESMF_StateItem_Flag)     :: itemFlag

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -1,886 +1,885 @@
 module mom_cap_methods
 
-  ! Cap import/export methods for both NEMS and CMEPS
+! Cap import/export methods for both NEMS and CMEPS
 
-  use ESMF,                only: ESMF_Clock, ESMF_ClockGet, ESMF_time, ESMF_TimeGet
-  use ESMF,                only: ESMF_TimeInterval, ESMF_TimeIntervalGet
-  use ESMF,                only: ESMF_State, ESMF_StateGet
-  use ESMF,                only: ESMF_Field, ESMF_FieldGet, ESMF_FieldCreate
-  use ESMF,                only: ESMF_GridComp, ESMF_Mesh, ESMF_Grid, ESMF_GridCreate
-  use ESMF,                only: ESMF_DistGrid, ESMF_DistGridCreate
-  use ESMF,                only: ESMF_KIND_R8, ESMF_SUCCESS, ESMF_LogFoundError
-  use ESMF,                only: ESMF_LOGERR_PASSTHRU, ESMF_LOGMSG_INFO, ESMF_LOGWRITE
-  use ESMF,                only: ESMF_LogSetError, ESMF_RC_MEM_ALLOCATE
-  use ESMF,                only: ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
-  use ESMF,                only: ESMF_GEOMTYPE_FLAG, ESMF_GEOMTYPE_GRID, ESMF_GEOMTYPE_MESH
-  use ESMF,                only: ESMF_RC_VAL_OUTOFRANGE, ESMF_INDEX_DELOCAL, ESMF_MESHLOC_ELEMENT
-  use ESMF,                only: ESMF_TYPEKIND_R8
-  use ESMF,                only: operator(/=), operator(==)
-  use MOM_ocean_model,     only: ocean_public_type, ocean_state_type
-  use MOM_surface_forcing, only: ice_ocean_boundary_type
-  use MOM_grid,            only: ocean_grid_type
-  use MOM_domains,         only: pass_var
-  use mpp_domains_mod,     only: mpp_get_compute_domain
+use ESMF,                only: ESMF_Clock, ESMF_ClockGet, ESMF_time, ESMF_TimeGet
+use ESMF,                only: ESMF_TimeInterval, ESMF_TimeIntervalGet
+use ESMF,                only: ESMF_State, ESMF_StateGet
+use ESMF,                only: ESMF_Field, ESMF_FieldGet, ESMF_FieldCreate
+use ESMF,                only: ESMF_GridComp, ESMF_Mesh, ESMF_Grid, ESMF_GridCreate
+use ESMF,                only: ESMF_DistGrid, ESMF_DistGridCreate
+use ESMF,                only: ESMF_KIND_R8, ESMF_SUCCESS, ESMF_LogFoundError
+use ESMF,                only: ESMF_LOGERR_PASSTHRU, ESMF_LOGMSG_INFO, ESMF_LOGWRITE
+use ESMF,                only: ESMF_LogSetError, ESMF_RC_MEM_ALLOCATE
+use ESMF,                only: ESMF_StateItem_Flag, ESMF_STATEITEM_NOTFOUND
+use ESMF,                only: ESMF_GEOMTYPE_FLAG, ESMF_GEOMTYPE_GRID, ESMF_GEOMTYPE_MESH
+use ESMF,                only: ESMF_RC_VAL_OUTOFRANGE, ESMF_INDEX_DELOCAL, ESMF_MESHLOC_ELEMENT
+use ESMF,                only: ESMF_TYPEKIND_R8
+use ESMF,                only: operator(/=), operator(==)
+use MOM_ocean_model,     only: ocean_public_type, ocean_state_type
+use MOM_surface_forcing, only: ice_ocean_boundary_type
+use MOM_grid,            only: ocean_grid_type
+use MOM_domains,         only: pass_var
+use mpp_domains_mod,     only: mpp_get_compute_domain
 
-  ! By default make data private
-  implicit none
-  private
+! By default make data private
+implicit none; private
 
-  ! Public member functions
-  public :: mom_set_geomtype
-  public :: mom_import
-  public :: mom_export
+! Public member functions
+public :: mom_set_geomtype
+public :: mom_import
+public :: mom_export
 
-  private :: State_getImport
-  private :: State_setExport
+private :: State_getImport
+private :: State_setExport
 
-  interface State_GetFldPtr
-     module procedure State_GetFldPtr_1d
-     module procedure State_GetFldPtr_2d
-  end interface
+interface State_GetFldPtr
+   module procedure State_GetFldPtr_1d
+   module procedure State_GetFldPtr_2d
+end interface
 
-  integer                  :: import_cnt = 0
-  type(ESMF_GeomType_Flag) :: geomtype
+integer                  :: import_cnt = 0
+type(ESMF_GeomType_Flag) :: geomtype
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine mom_set_geomtype(geomtype_in)
-    ! Set module variable geomtype
+subroutine mom_set_geomtype(geomtype_in)
+  ! Set module variable geomtype
 
-    type(ESMF_GeomType_Flag), intent(in)    :: geomtype_in     !< mesh or grid
+  type(ESMF_GeomType_Flag), intent(in)    :: geomtype_in     !< mesh or grid
 
-    geomtype = geomtype_in
+  geomtype = geomtype_in
 
-  end subroutine mom_set_geomtype
-
-!===============================================================================
-
-  !> This function has a few purposes:
-  !! (1) it imports surface fluxes using data from the mediator; and
-  !! (2) it can apply restoring in SST and SSS.
-
-  subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype, rc)
-
-    ! Input/output variables
-    type(ocean_public_type)       , intent(in)    :: ocean_public       !< Ocean surface state
-    type(ocean_grid_type)         , intent(in)    :: ocean_grid         !< Ocean model grid
-    type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
-    type(ice_ocean_boundary_type) , intent(inout) :: ice_ocean_boundary !< Ocean boundary forcing
-    character(len=*), optional    , intent(in)    :: runtype            !< For cesm only, type of run
-    integer                       , intent(inout) :: rc
-
-    ! Local Variables
-    integer                         :: i, j, ig, jg, n
-    integer                         :: isc, iec, jsc, jec
-    logical                         :: do_import
-    character(len=128)              :: fldname
-    real(ESMF_KIND_R8), allocatable :: taux(:,:)
-    real(ESMF_KIND_R8), allocatable :: tauy(:,:)
-    character(len=*)  , parameter   :: subname = '(mom_import)'
-
-    !-----------------------------------------------------------------------
-
-    rc = ESMF_SUCCESS
-
-    ! -------
-    ! import_cnt is used to skip using the import state at the first count for cesm
-    ! -------
-
-    if (present(runtype)) then
-       import_cnt = import_cnt + 1
-       if ((trim(runtype) == 'initial' .and. import_cnt <= 2)) then
-          do_import = .false. ! This will skip the first time import information is given
-       else
-          do_import = .true.
-       end if
-    else
-       do_import = .true.
-    end if
-
-    if (do_import) then
-       ! The following are global indices without halos
-       call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
-
-       !----
-       ! surface height pressure
-       !----
-       call state_getimport(importState, 'inst_pres_height_surface', &
-            isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! near-IR, direct shortwave  (W/m2)
-       !----
-       call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
-            isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! near-IR, diffuse shortwave  (W/m2)
-       !----
-       call state_getimport(importState, 'mean_net_sw_ir_dif_flx', &
-            isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dif, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! visible, direct shortwave  (W/m2)
-       !----
-       call state_getimport(importState, 'mean_net_sw_vis_dir_flx', &
-            isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dir, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! visible, diffuse shortwave (W/m2)
-       !----
-       call state_getimport(importState, 'mean_net_sw_vis_dif_flx', &
-            isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dif, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! -------
-       ! Net longwave radiation (W/m2)
-       ! -------
-       call state_getimport(importState, 'mean_net_lw_flx',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%lw_flux, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! zonal and meridional surface stress
-       !----
-       allocate (taux(isc:iec,jsc:jec))
-       allocate (tauy(isc:iec,jsc:jec))
-
-       call state_getimport(importState, 'mean_zonal_moment_flx', isc, iec, jsc, jec, taux, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-       call state_getimport(importState, 'mean_merid_moment_flx', isc, iec, jsc, jec, tauy, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! rotate taux and tauy from true zonal/meridional to local coordinates
-       do j = jsc, jec
-          jg = j + ocean_grid%jsc - jsc
-          do i = isc, iec
-             ig = i + ocean_grid%isc - isc
-             ice_ocean_boundary%u_flux(i,j) = ocean_grid%cos_rot(ig,jg)*taux(i,j) &
-                                            - ocean_grid%sin_rot(ig,jg)*tauy(i,j)
-             ice_ocean_boundary%v_flux(i,j) = ocean_grid%cos_rot(ig,jg)*tauy(i,j) &
-                                            + ocean_grid%sin_rot(ig,jg)*taux(i,j)
-          end do
-       end do
-
-       deallocate(taux, tauy)
-
-       !----
-       ! sensible heat flux (W/m2)
-       !----
-       call state_getimport(importState, 'mean_sensi_heat_flx', &
-            isc, iec, jsc, jec, ice_ocean_boundary%t_flux, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! evaporation flux (W/m2)
-       !----
-       call state_getimport(importState, 'mean_evap_rate', &
-            isc, iec, jsc, jec, ice_ocean_boundary%q_flux, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! liquid precipitation (rain)
-       !----
-       call state_getimport(importState, 'mean_prec_rate', &
-            isc, iec, jsc, jec, ice_ocean_boundary%lprec, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! frozen precipitation (snow)
-       !----
-       call state_getimport(importState, 'mean_fprec_rate', &
-            isc, iec, jsc, jec, ice_ocean_boundary%fprec, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! runoff and heat content of runoff
-       !----
-       ! Note - preset values to 0, if field does not exist in importState, then will simply return
-       ! and preset value will be used
-
-       ! liquid runoff
-       ice_ocean_boundary%rofl_flux (:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'Foxx_rofl',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%rofl_flux,rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! ice runoff
-       ice_ocean_boundary%rofi_flux (:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'Foxx_rofi',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%rofi_flux,rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! total runoff
-       ice_ocean_boundary%runoff (:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'mean_runoff_rate',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%runoff, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! heat content of runoff
-       ice_ocean_boundary%runoff_hflx(:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'mean_runoff_heat_flux',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%runoff_hflx, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! calving rate and heat flux
-       !----
-       ! Note - preset values to 0, if field does not exist in importState, then will simply return
-       ! and preset value will be used
-
-       ice_ocean_boundary%calving(:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'mean_calving_rate',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%calving, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ice_ocean_boundary%calving_hflx(:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'mean_calving_heat_flux',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%calving_hflx, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       !----
-       ! salt flux from ice
-       !----
-       call state_getimport(importState, 'mean_salt_rate',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%salt_flux,rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-       ! !----
-       ! ! snow&ice melt heat flux  (W/m^2)
-       ! !----
-       ! call state_getimport(importState, 'seaice_melt_heat',  &
-       !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat,rc=rc)
-       ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-       !      line=__LINE__, &
-       !      file=__FILE__)) &
-       !      return  ! bail out
-
-       ! !----
-       ! ! snow&ice melt water flux  (W/m^2)
-       ! !----
-       ! call state_getimport(importState, 'seaice_melt_water',  &
-       !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_water,rc=rc)
-       ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-       !      line=__LINE__, &
-       !      file=__FILE__)) &
-       !      return  ! bail out
-
-       !----
-       ! mass of overlying ice
-       !----
-       ! Note - preset values to 0, if field does not exist in importState, then will simply return
-       ! and preset value will be used
-
-       ice_ocean_boundary%mi(:,:) = 0._ESMF_KIND_R8
-       call state_getimport(importState, 'mass_of_overlying_ice',  &
-            isc, iec, jsc, jec, ice_ocean_boundary%mi, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-
-    end if
-
-  end subroutine mom_import
+end subroutine mom_set_geomtype
 
 !===============================================================================
 
-  !> Maps outgoing ocean data to ESMF State
-  subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc)
+!> This function has a few purposes:
+!! (1) it imports surface fluxes using data from the mediator; and
+!! (2) it can apply restoring in SST and SSS.
 
-    ! Input/output variables
-    type(ocean_public_type) , intent(in)    :: ocean_public !< Ocean surface state
-    type(ocean_grid_type)   , intent(in)    :: ocean_grid   !< Ocean model grid
-    type(ocean_state_type)  , pointer       :: ocean_state
-    type(ESMF_State)        , intent(inout) :: exportState  !< outgoing data
-    type(ESMF_Clock)        , intent(in)    :: clock
-    integer                 , intent(inout) :: rc
+subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype, rc)
 
-    ! Local variables
-    integer                         :: i, j, ig, jg         ! indices
-    integer                         :: isc, iec, jsc, jec   ! indices
-    integer                         :: iloc, jloc           ! indices
-    integer                         :: iglob, jglob         ! indices
-    integer                         :: n
-    integer                         :: icount
-    real                            :: slp_L, slp_R, slp_C
-    real                            :: slope, u_min, u_max
-    integer                         :: day, secs
-    type(ESMF_TimeInterval)         :: timeStep
-    integer                         :: dt_int
-    real                            :: inv_dt_int  !< The inverse of coupling time interval in s-1.
-    type(ESMF_StateItem_Flag)       :: itemFlag
-    real(ESMF_KIND_R8), allocatable :: omask(:,:)
-    real(ESMF_KIND_R8), allocatable :: melt_potential(:,:)
-    real(ESMF_KIND_R8), allocatable :: ocz(:,:), ocm(:,:)
-    real(ESMF_KIND_R8), allocatable :: ocz_rot(:,:), ocm_rot(:,:)
-    real(ESMF_KIND_R8), allocatable :: ssh(:,:)
-    real(ESMF_KIND_R8), allocatable :: dhdx(:,:), dhdy(:,:)
-    real(ESMF_KIND_R8), allocatable :: dhdx_rot(:,:), dhdy_rot(:,:)
-    character(len=*)  , parameter   :: subname = '(mom_export)'
-    !-----------------------------------------------------------------------
+  ! Input/output variables
+  type(ocean_public_type)       , intent(in)    :: ocean_public       !< Ocean surface state
+  type(ocean_grid_type)         , intent(in)    :: ocean_grid         !< Ocean model grid
+  type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
+  type(ice_ocean_boundary_type) , intent(inout) :: ice_ocean_boundary !< Ocean boundary forcing
+  character(len=*), optional    , intent(in)    :: runtype            !< For cesm only, type of run
+  integer                       , intent(inout) :: rc
 
-    rc = ESMF_SUCCESS
+  ! Local Variables
+  integer                         :: i, j, ig, jg, n
+  integer                         :: isc, iec, jsc, jec
+  logical                         :: do_import
+  character(len=128)              :: fldname
+  real(ESMF_KIND_R8), allocatable :: taux(:,:)
+  real(ESMF_KIND_R8), allocatable :: tauy(:,:)
+  character(len=*)  , parameter   :: subname = '(mom_import)'
 
-    ! Use Adcroft's rule of reciprocals; it does the right thing here.
-    call ESMF_ClockGet( clock, timeStep=timeStep, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  !-----------------------------------------------------------------------
 
-    call ESMF_TimeIntervalGet( timeStep, s=dt_int, rc=rc )
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  rc = ESMF_SUCCESS
 
-    if (real(dt_int) > 0.0) then
-       inv_dt_int = 1.0 / real(dt_int)
-    else
-       inv_dt_int = 0.0
-    end if
+  ! -------
+  ! import_cnt is used to skip using the import state at the first count for cesm
+  ! -------
 
-    !----------------
-    ! Copy from ocean_public to exportstate.
-    !----------------
+  if (present(runtype)) then
+     import_cnt = import_cnt + 1
+     if ((trim(runtype) == 'initial' .and. import_cnt <= 2)) then
+	do_import = .false. ! This will skip the first time import information is given
+     else
+	do_import = .true.
+     end if
+  else
+     do_import = .true.
+  end if
 
-    call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
+  if (do_import) then
+     ! The following are global indices without halos
+     call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
 
-    ! -------
-    ! ocean mask
-    ! -------
+     !----
+     ! surface height pressure
+     !----
+     call state_getimport(importState, 'inst_pres_height_surface', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%p, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    allocate(omask(isc:iec, jsc:jec))
-    do j = jsc, jec
-       jg = j + ocean_grid%jsc - jsc
-       do i = isc, iec
-          ig = i + ocean_grid%isc - isc
-          omask(i,j) = nint(ocean_grid%mask2dT(ig,jg))
-       enddo
-    enddo
+     !----
+     ! near-IR, direct shortwave  (W/m2)
+     !----
+     call state_getimport(importState, 'mean_net_sw_ir_dir_flx', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dir, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    call State_SetExport(exportState, 'ocean_mask', &
-         isc, iec, jsc, jec, omask, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     !----
+     ! near-IR, diffuse shortwave  (W/m2)
+     !----
+     call state_getimport(importState, 'mean_net_sw_ir_dif_flx', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_nir_dif, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    deallocate(omask)
+     !----
+     ! visible, direct shortwave  (W/m2)
+     !----
+     call state_getimport(importState, 'mean_net_sw_vis_dir_flx', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dir, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! Sea surface temperature
-    ! -------
-    call State_SetExport(exportState, 'sea_surface_temperature', &
-         isc, iec, jsc, jec, ocean_public%t_surf, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     !----
+     ! visible, diffuse shortwave (W/m2)
+     !----
+     call state_getimport(importState, 'mean_net_sw_vis_dif_flx', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%sw_flux_vis_dif, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! Sea surface salinity
-    ! -------
-    call State_SetExport(exportState, 's_surf', &
-         isc, iec, jsc, jec, ocean_public%s_surf, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     ! -------
+     ! Net longwave radiation (W/m2)
+     ! -------
+     call state_getimport(importState, 'mean_net_lw_flx',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%lw_flux, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! zonal and meridional currents
-    ! -------
+     !----
+     ! zonal and meridional surface stress
+     !----
+     allocate (taux(isc:iec,jsc:jec))
+     allocate (tauy(isc:iec,jsc:jec))
 
-    ! rotate ocn current from tripolar grid back to lat/lon grid x,y => latlon (CCW)
-    ! "ocean_grid" has halos and uses local indexing.
+     call state_getimport(importState, 'mean_zonal_moment_flx', isc, iec, jsc, jec, taux, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+     call state_getimport(importState, 'mean_merid_moment_flx', isc, iec, jsc, jec, tauy, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    allocate(ocz(isc:iec, jsc:jec))
-    allocate(ocm(isc:iec, jsc:jec))
-    allocate(ocz_rot(isc:iec, jsc:jec))
-    allocate(ocm_rot(isc:iec, jsc:jec))
+     ! rotate taux and tauy from true zonal/meridional to local coordinates
+     do j = jsc, jec
+	jg = j + ocean_grid%jsc - jsc
+	do i = isc, iec
+	   ig = i + ocean_grid%isc - isc
+	   ice_ocean_boundary%u_flux(i,j) = ocean_grid%cos_rot(ig,jg)*taux(i,j) &
+					  - ocean_grid%sin_rot(ig,jg)*tauy(i,j)
+	   ice_ocean_boundary%v_flux(i,j) = ocean_grid%cos_rot(ig,jg)*tauy(i,j) &
+					  + ocean_grid%sin_rot(ig,jg)*taux(i,j)
+	end do
+     end do
 
-    do j = jsc, jec
-       jg = j + ocean_grid%jsc - jsc
-       do i = isc, iec
-          ig = i + ocean_grid%isc - isc
-          ocz(i,j) = ocean_public%u_surf(i,j)
-          ocm(i,j) = ocean_public%v_surf(i,j)
-          ocz_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocz(i,j) + ocean_grid%sin_rot(ig,jg)*ocm(i,j)
-          ocm_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocm(i,j) - ocean_grid%sin_rot(ig,jg)*ocz(i,j)
-       end do
-    end do
+     deallocate(taux, tauy)
 
-    call State_SetExport(exportState, 'ocn_current_zonal', &
-         isc, iec, jsc, jec, ocz_rot, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     !----
+     ! sensible heat flux (W/m2)
+     !----
+     call state_getimport(importState, 'mean_sensi_heat_flx', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%t_flux, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    call State_SetExport(exportState, 'ocn_current_merid', &
-         isc, iec, jsc, jec, ocm_rot, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     !----
+     ! evaporation flux (W/m2)
+     !----
+     call state_getimport(importState, 'mean_evap_rate', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%q_flux, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    deallocate(ocz, ocm, ocz_rot, ocm_rot)
+     !----
+     ! liquid precipitation (rain)
+     !----
+     call state_getimport(importState, 'mean_prec_rate', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%lprec, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! Boundary layer depth
-    ! -------
-    call ESMF_StateGet(exportState, 'So_bldepth', itemFlag, rc=rc)
-    if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
-       call State_SetExport(exportState, 'So_bldepth', &
-            isc, iec, jsc, jec, ocean_public%obld, ocean_grid, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-    end if
+     !----
+     ! frozen precipitation (snow)
+     !----
+     call state_getimport(importState, 'mean_fprec_rate', &
+	  isc, iec, jsc, jec, ice_ocean_boundary%fprec, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! Freezing melting potential
-    ! -------
-    ! melt_potential, defined positive for T>Tfreeze, so need to change sign
-    ! Convert from J/m^2 to W/m^2 and make sure Melt_potential is always <= 0
+     !----
+     ! runoff and heat content of runoff
+     !----
+     ! Note - preset values to 0, if field does not exist in importState, then will simply return
+     ! and preset value will be used
 
-    allocate(melt_potential(isc:iec, jsc:jec))
+     ! liquid runoff
+     ice_ocean_boundary%rofl_flux (:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'Foxx_rofl',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%rofl_flux,rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    do j = jsc,jec
-       do i = isc,iec
-          if (ocean_public%frazil(i,j) > 0.0) then
-             melt_potential(i,j) =  ocean_public%frazil(i,j) * inv_dt_int
-          else
-             melt_potential(i,j) = -ocean_public%melt_potential(i,j) * inv_dt_int
-             if (melt_potential(i,j) > 0.0) melt_potential(i,j) = 0.0
-          end if
-       end do
-    end do
+     ! ice runoff
+     ice_ocean_boundary%rofi_flux (:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'Foxx_rofi',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%rofi_flux,rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    call State_SetExport(exportState, 'freezing_melting_potential', &
-         isc, iec, jsc, jec, melt_potential, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
+     ! total runoff
+     ice_ocean_boundary%runoff (:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'mean_runoff_rate',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%runoff, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    deallocate(melt_potential)
+     ! heat content of runoff
+     ice_ocean_boundary%runoff_hflx(:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'mean_runoff_heat_flux',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%runoff_hflx, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! -------
-    ! Sea level
-    ! -------
-    call ESMF_StateGet(exportState, 'sea_level', itemFlag, rc=rc)
-    if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
-       call State_SetExport(exportState, 'sea_level', &
-            isc, iec, jsc, jec, ocean_public%sea_lev, ocean_grid, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return  ! bail out
-    end if
+     !----
+     ! calving rate and heat flux
+     !----
+     ! Note - preset values to 0, if field does not exist in importState, then will simply return
+     ! and preset value will be used
 
-    !----------------
-    ! Sea-surface zonal and meridional slopes
-    !----------------
+     ice_ocean_boundary%calving(:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'mean_calving_rate',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%calving, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    allocate(ssh(ocean_grid%isd:ocean_grid%ied,ocean_grid%jsd:ocean_grid%jed)) ! local indices with halos
-    allocate(dhdx(isc:iec, jsc:jec))     !global indices without halos
-    allocate(dhdy(isc:iec, jsc:jec))     !global indices without halos
-    allocate(dhdx_rot(isc:iec, jsc:jec)) !global indices without halos
-    allocate(dhdy_rot(isc:iec, jsc:jec)) !global indices without halos
+     ice_ocean_boundary%calving_hflx(:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'mean_calving_heat_flux',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%calving_hflx, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ssh  = 0.0_ESMF_KIND_R8
-    dhdx = 0.0_ESMF_KIND_R8
-    dhdy = 0.0_ESMF_KIND_R8
+     !----
+     ! salt flux from ice
+     !----
+     call state_getimport(importState, 'mean_salt_rate',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%salt_flux,rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! Make a copy of ssh in order to do a halo update (ssh has local indexing with halos)
-    do j = ocean_grid%jsc, ocean_grid%jec
-       jloc = j + ocean_grid%jdg_offset
-       do i = ocean_grid%isc,ocean_grid%iec
-          iloc = i + ocean_grid%idg_offset
-          ssh(i,j) = ocean_public%sea_lev(iloc,jloc)
-       end do
-    end do
+     ! !----
+     ! ! snow&ice melt heat flux  (W/m^2)
+     ! !----
+     ! call state_getimport(importState, 'seaice_melt_heat',  &
+     !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_heat,rc=rc)
+     ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+     !      line=__LINE__, &
+     !      file=__FILE__)) &
+     !      return  ! bail out
 
-    ! Update halo of ssh so we can calculate gradients (local indexing)
-    call pass_var(ssh, ocean_grid%domain)
+     ! !----
+     ! ! snow&ice melt water flux  (W/m^2)
+     ! !----
+     ! call state_getimport(importState, 'seaice_melt_water',  &
+     !      isc, iec, jsc, jec, ice_ocean_boundary%seaice_melt_water,rc=rc)
+     ! if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+     !      line=__LINE__, &
+     !      file=__FILE__)) &
+     !      return  ! bail out
 
-    ! d/dx ssh
-    ! This is a simple second-order difference
-    ! dhdx(i,j) = 0.5 * (ssh(i+1,j) - ssh(i-1,j)) * ocean_grid%IdxT(i,j) * ocean_grid%mask2dT(ig,jg)
+     !----
+     ! mass of overlying ice
+     !----
+     ! Note - preset values to 0, if field does not exist in importState, then will simply return
+     ! and preset value will be used
 
-    do jglob = jsc, jec
-      j  = jglob + ocean_grid%jsc - jsc
-      do iglob = isc,iec
-        i  = iglob + ocean_grid%isc - isc
-        ! This is a PLM slope which might be less prone to the A-grid null mode
-        slp_L = (ssh(I,j) - ssh(I-1,j)) * ocean_grid%mask2dCu(i-1,j)
-        if (ocean_grid%mask2dCu(i-1,j)==0.) slp_L = 0.
-        slp_R = (ssh(I+1,j) - ssh(I,j)) * ocean_grid%mask2dCu(i,j)
-        if (ocean_grid%mask2dCu(i+1,j)==0.) slp_R = 0.
-        slp_C = 0.5 * (slp_L + slp_R)
-        if ( (slp_L * slp_R) > 0.0 ) then
-          ! This limits the slope so that the edge values are bounded by the
-          ! two cell averages spanning the edge.
-          u_min = min( ssh(i-1,j), ssh(i,j), ssh(i+1,j) )
-          u_max = max( ssh(i-1,j), ssh(i,j), ssh(i+1,j) )
-          slope = sign( min( abs(slp_C), 2.*min( ssh(i,j) - u_min, u_max - ssh(i,j) ) ), slp_C )
-        else
-          ! Extrema in the mean values require a PCM reconstruction avoid generating
-          ! larger extreme values.
-          slope = 0.0
-        end if
-        dhdx(iglob,jglob) = slope * ocean_grid%IdxT(i,j) * ocean_grid%mask2dT(i,j)
-        if (ocean_grid%mask2dT(i,j)==0.) dhdx(iglob,jglob) = 0.0
-      end do
-    end do
+     ice_ocean_boundary%mi(:,:) = 0._ESMF_KIND_R8
+     call state_getimport(importState, 'mass_of_overlying_ice',  &
+	  isc, iec, jsc, jec, ice_ocean_boundary%mi, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
 
-    ! d/dy ssh
-    ! This is a simple second-order difference
-    ! dhdy(i,j) = 0.5 * (ssh(i,j+1) - ssh(i,j-1)) * ocean_grid%IdyT(i,j) * ocean_grid%mask2dT(ig,jg)
+  end if
 
-    do jglob = jsc, jec
-      j = jglob + ocean_grid%jsc - jsc
-      do iglob = isc,iec
-         i = iglob + ocean_grid%isc - isc
-        ! This is a PLM slope which might be less prone to the A-ocean_grid null mode
-        slp_L = ssh(i,J) - ssh(i,J-1) * ocean_grid%mask2dCv(i,j-1)
-        if (ocean_grid%mask2dCv(i,j-1)==0.) slp_L = 0.
-        slp_R = ssh(i,J+1) - ssh(i,J) * ocean_grid%mask2dCv(i,j)
-        if (ocean_grid%mask2dCv(i,j+1)==0.) slp_R = 0.
-        slp_C = 0.5 * (slp_L + slp_R)
-        if ((slp_L * slp_R) > 0.0) then
-          ! This limits the slope so that the edge values are bounded by the
-          ! two cell averages spanning the edge.
-          u_min = min( ssh(i,j-1), ssh(i,j), ssh(i,j+1) )
-          u_max = max( ssh(i,j-1), ssh(i,j), ssh(i,j+1) )
-          slope = sign( min( abs(slp_C), 2.*min( ssh(i,j) - u_min, u_max - ssh(i,j) ) ), slp_C )
-        else
-          ! Extrema in the mean values require a PCM reconstruction avoid generating
-          ! larger extreme values.
-          slope = 0.0
-        end if
-        dhdy(iglob,jglob) = slope * ocean_grid%IdyT(i,j) * ocean_grid%mask2dT(i,j)
-        if (ocean_grid%mask2dT(i,j)==0.) dhdy(iglob,jglob) = 0.0
-      end do
-    end do
-
-    ! rotate slopes from tripolar grid back to lat/lon grid,  x,y => latlon (CCW)
-    ! "ocean_grid" uses has halos and uses local indexing.
-
-    do j = jsc, jec
-       jg = j + ocean_grid%jsc - jsc
-       do i = isc, iec
-          ig = i + ocean_grid%isc - isc
-          dhdx_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdx(i,j) + ocean_grid%sin_rot(ig,jg)*dhdy(i,j)
-          dhdy_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdy(i,j) - ocean_grid%sin_rot(ig,jg)*dhdx(i,j)
-       end do
-    end do
-
-    call State_SetExport(exportState, 'sea_surface_slope_zonal', &
-         isc, iec, jsc, jec, dhdx_rot, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-
-    call State_SetExport(exportState, 'sea_surface_slope_merid', &
-         isc, iec, jsc, jec, dhdy_rot, ocean_grid, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return  ! bail out
-
-    deallocate(ssh, dhdx, dhdy, dhdx_rot, dhdy_rot)
-
-  end subroutine mom_export
+end subroutine mom_import
 
 !===============================================================================
 
-  subroutine State_GetFldPtr_1d(State, fldname, fldptr, rc)
-    type(ESMF_State)            , intent(in)  :: State
-    character(len=*)            , intent(in)  :: fldname
-    real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:)
-    integer, optional           , intent(out) :: rc
+!> Maps outgoing ocean data to ESMF State
+subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc)
 
-    ! local variables
-    type(ESMF_Field) :: lfield
-    integer :: lrc
-    character(len=*),parameter :: subname='(mom_cap:State_GetFldPtr)'
+  ! Input/output variables
+  type(ocean_public_type) , intent(in)    :: ocean_public !< Ocean surface state
+  type(ocean_grid_type)   , intent(in)    :: ocean_grid   !< Ocean model grid
+  type(ocean_state_type)  , pointer       :: ocean_state
+  type(ESMF_State)        , intent(inout) :: exportState  !< outgoing data
+  type(ESMF_Clock)        , intent(in)    :: clock
+  integer                 , intent(inout) :: rc
 
-    call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_FieldGet(lfield, farrayPtr=fldptr, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  ! Local variables
+  integer                         :: i, j, ig, jg         ! indices
+  integer                         :: isc, iec, jsc, jec   ! indices
+  integer                         :: iloc, jloc           ! indices
+  integer                         :: iglob, jglob         ! indices
+  integer                         :: n
+  integer                         :: icount
+  real                            :: slp_L, slp_R, slp_C
+  real                            :: slope, u_min, u_max
+  integer                         :: day, secs
+  type(ESMF_TimeInterval)         :: timeStep
+  integer                         :: dt_int
+  real                            :: inv_dt_int  !< The inverse of coupling time interval in s-1.
+  type(ESMF_StateItem_Flag)       :: itemFlag
+  real(ESMF_KIND_R8), allocatable :: omask(:,:)
+  real(ESMF_KIND_R8), allocatable :: melt_potential(:,:)
+  real(ESMF_KIND_R8), allocatable :: ocz(:,:), ocm(:,:)
+  real(ESMF_KIND_R8), allocatable :: ocz_rot(:,:), ocm_rot(:,:)
+  real(ESMF_KIND_R8), allocatable :: ssh(:,:)
+  real(ESMF_KIND_R8), allocatable :: dhdx(:,:), dhdy(:,:)
+  real(ESMF_KIND_R8), allocatable :: dhdx_rot(:,:), dhdy_rot(:,:)
+  character(len=*)  , parameter   :: subname = '(mom_export)'
+  !-----------------------------------------------------------------------
 
-    if (present(rc)) rc = lrc
+  rc = ESMF_SUCCESS
 
-  end subroutine State_GetFldPtr_1d
+  ! Use Adcroft's rule of reciprocals; it does the right thing here.
+  call ESMF_ClockGet( clock, timeStep=timeStep, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  call ESMF_TimeIntervalGet( timeStep, s=dt_int, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+
+  if (real(dt_int) > 0.0) then
+     inv_dt_int = 1.0 / real(dt_int)
+  else
+     inv_dt_int = 0.0
+  end if
+
+  !----------------
+  ! Copy from ocean_public to exportstate.
+  !----------------
+
+  call mpp_get_compute_domain(ocean_public%domain, isc, iec, jsc, jec)
+
+  ! -------
+  ! ocean mask
+  ! -------
+
+  allocate(omask(isc:iec, jsc:jec))
+  do j = jsc, jec
+     jg = j + ocean_grid%jsc - jsc
+     do i = isc, iec
+	ig = i + ocean_grid%isc - isc
+	omask(i,j) = nint(ocean_grid%mask2dT(ig,jg))
+     enddo
+  enddo
+
+  call State_SetExport(exportState, 'ocean_mask', &
+       isc, iec, jsc, jec, omask, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  deallocate(omask)
+
+  ! -------
+  ! Sea surface temperature
+  ! -------
+  call State_SetExport(exportState, 'sea_surface_temperature', &
+       isc, iec, jsc, jec, ocean_public%t_surf, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  ! -------
+  ! Sea surface salinity
+  ! -------
+  call State_SetExport(exportState, 's_surf', &
+       isc, iec, jsc, jec, ocean_public%s_surf, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  ! -------
+  ! zonal and meridional currents
+  ! -------
+
+  ! rotate ocn current from tripolar grid back to lat/lon grid x,y => latlon (CCW)
+  ! "ocean_grid" has halos and uses local indexing.
+
+  allocate(ocz(isc:iec, jsc:jec))
+  allocate(ocm(isc:iec, jsc:jec))
+  allocate(ocz_rot(isc:iec, jsc:jec))
+  allocate(ocm_rot(isc:iec, jsc:jec))
+
+  do j = jsc, jec
+     jg = j + ocean_grid%jsc - jsc
+     do i = isc, iec
+	ig = i + ocean_grid%isc - isc
+	ocz(i,j) = ocean_public%u_surf(i,j)
+	ocm(i,j) = ocean_public%v_surf(i,j)
+	ocz_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocz(i,j) + ocean_grid%sin_rot(ig,jg)*ocm(i,j)
+	ocm_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocm(i,j) - ocean_grid%sin_rot(ig,jg)*ocz(i,j)
+     end do
+  end do
+
+  call State_SetExport(exportState, 'ocn_current_zonal', &
+       isc, iec, jsc, jec, ocz_rot, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  call State_SetExport(exportState, 'ocn_current_merid', &
+       isc, iec, jsc, jec, ocm_rot, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  deallocate(ocz, ocm, ocz_rot, ocm_rot)
+
+  ! -------
+  ! Boundary layer depth
+  ! -------
+  call ESMF_StateGet(exportState, 'So_bldepth', itemFlag, rc=rc)
+  if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
+     call State_SetExport(exportState, 'So_bldepth', &
+	  isc, iec, jsc, jec, ocean_public%obld, ocean_grid, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+  end if
+
+  ! -------
+  ! Freezing melting potential
+  ! -------
+  ! melt_potential, defined positive for T>Tfreeze, so need to change sign
+  ! Convert from J/m^2 to W/m^2 and make sure Melt_potential is always <= 0
+
+  allocate(melt_potential(isc:iec, jsc:jec))
+
+  do j = jsc,jec
+     do i = isc,iec
+	if (ocean_public%frazil(i,j) > 0.0) then
+	   melt_potential(i,j) =  ocean_public%frazil(i,j) * inv_dt_int
+	else
+	   melt_potential(i,j) = -ocean_public%melt_potential(i,j) * inv_dt_int
+	   if (melt_potential(i,j) > 0.0) melt_potential(i,j) = 0.0
+	end if
+     end do
+  end do
+
+  call State_SetExport(exportState, 'freezing_melting_potential', &
+       isc, iec, jsc, jec, melt_potential, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  deallocate(melt_potential)
+
+  ! -------
+  ! Sea level
+  ! -------
+  call ESMF_StateGet(exportState, 'sea_level', itemFlag, rc=rc)
+  if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
+     call State_SetExport(exportState, 'sea_level', &
+	  isc, iec, jsc, jec, ocean_public%sea_lev, ocean_grid, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return  ! bail out
+  end if
+
+  !----------------
+  ! Sea-surface zonal and meridional slopes
+  !----------------
+
+  allocate(ssh(ocean_grid%isd:ocean_grid%ied,ocean_grid%jsd:ocean_grid%jed)) ! local indices with halos
+  allocate(dhdx(isc:iec, jsc:jec))     !global indices without halos
+  allocate(dhdy(isc:iec, jsc:jec))     !global indices without halos
+  allocate(dhdx_rot(isc:iec, jsc:jec)) !global indices without halos
+  allocate(dhdy_rot(isc:iec, jsc:jec)) !global indices without halos
+
+  ssh  = 0.0_ESMF_KIND_R8
+  dhdx = 0.0_ESMF_KIND_R8
+  dhdy = 0.0_ESMF_KIND_R8
+
+  ! Make a copy of ssh in order to do a halo update (ssh has local indexing with halos)
+  do j = ocean_grid%jsc, ocean_grid%jec
+     jloc = j + ocean_grid%jdg_offset
+     do i = ocean_grid%isc,ocean_grid%iec
+	iloc = i + ocean_grid%idg_offset
+	ssh(i,j) = ocean_public%sea_lev(iloc,jloc)
+     end do
+  end do
+
+  ! Update halo of ssh so we can calculate gradients (local indexing)
+  call pass_var(ssh, ocean_grid%domain)
+
+  ! d/dx ssh
+  ! This is a simple second-order difference
+  ! dhdx(i,j) = 0.5 * (ssh(i+1,j) - ssh(i-1,j)) * ocean_grid%IdxT(i,j) * ocean_grid%mask2dT(ig,jg)
+
+  do jglob = jsc, jec
+    j  = jglob + ocean_grid%jsc - jsc
+    do iglob = isc,iec
+      i  = iglob + ocean_grid%isc - isc
+      ! This is a PLM slope which might be less prone to the A-grid null mode
+      slp_L = (ssh(I,j) - ssh(I-1,j)) * ocean_grid%mask2dCu(i-1,j)
+      if (ocean_grid%mask2dCu(i-1,j)==0.) slp_L = 0.
+      slp_R = (ssh(I+1,j) - ssh(I,j)) * ocean_grid%mask2dCu(i,j)
+      if (ocean_grid%mask2dCu(i+1,j)==0.) slp_R = 0.
+      slp_C = 0.5 * (slp_L + slp_R)
+      if ( (slp_L * slp_R) > 0.0 ) then
+	! This limits the slope so that the edge values are bounded by the
+	! two cell averages spanning the edge.
+	u_min = min( ssh(i-1,j), ssh(i,j), ssh(i+1,j) )
+	u_max = max( ssh(i-1,j), ssh(i,j), ssh(i+1,j) )
+	slope = sign( min( abs(slp_C), 2.*min( ssh(i,j) - u_min, u_max - ssh(i,j) ) ), slp_C )
+      else
+	! Extrema in the mean values require a PCM reconstruction avoid generating
+	! larger extreme values.
+	slope = 0.0
+      end if
+      dhdx(iglob,jglob) = slope * ocean_grid%IdxT(i,j) * ocean_grid%mask2dT(i,j)
+      if (ocean_grid%mask2dT(i,j)==0.) dhdx(iglob,jglob) = 0.0
+    end do
+  end do
+
+  ! d/dy ssh
+  ! This is a simple second-order difference
+  ! dhdy(i,j) = 0.5 * (ssh(i,j+1) - ssh(i,j-1)) * ocean_grid%IdyT(i,j) * ocean_grid%mask2dT(ig,jg)
+
+  do jglob = jsc, jec
+    j = jglob + ocean_grid%jsc - jsc
+    do iglob = isc,iec
+       i = iglob + ocean_grid%isc - isc
+      ! This is a PLM slope which might be less prone to the A-ocean_grid null mode
+      slp_L = ssh(i,J) - ssh(i,J-1) * ocean_grid%mask2dCv(i,j-1)
+      if (ocean_grid%mask2dCv(i,j-1)==0.) slp_L = 0.
+      slp_R = ssh(i,J+1) - ssh(i,J) * ocean_grid%mask2dCv(i,j)
+      if (ocean_grid%mask2dCv(i,j+1)==0.) slp_R = 0.
+      slp_C = 0.5 * (slp_L + slp_R)
+      if ((slp_L * slp_R) > 0.0) then
+	! This limits the slope so that the edge values are bounded by the
+	! two cell averages spanning the edge.
+	u_min = min( ssh(i,j-1), ssh(i,j), ssh(i,j+1) )
+	u_max = max( ssh(i,j-1), ssh(i,j), ssh(i,j+1) )
+	slope = sign( min( abs(slp_C), 2.*min( ssh(i,j) - u_min, u_max - ssh(i,j) ) ), slp_C )
+      else
+	! Extrema in the mean values require a PCM reconstruction avoid generating
+	! larger extreme values.
+	slope = 0.0
+      end if
+      dhdy(iglob,jglob) = slope * ocean_grid%IdyT(i,j) * ocean_grid%mask2dT(i,j)
+      if (ocean_grid%mask2dT(i,j)==0.) dhdy(iglob,jglob) = 0.0
+    end do
+  end do
+
+  ! rotate slopes from tripolar grid back to lat/lon grid,  x,y => latlon (CCW)
+  ! "ocean_grid" uses has halos and uses local indexing.
+
+  do j = jsc, jec
+     jg = j + ocean_grid%jsc - jsc
+     do i = isc, iec
+	ig = i + ocean_grid%isc - isc
+	dhdx_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdx(i,j) + ocean_grid%sin_rot(ig,jg)*dhdy(i,j)
+	dhdy_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdy(i,j) - ocean_grid%sin_rot(ig,jg)*dhdx(i,j)
+     end do
+  end do
+
+  call State_SetExport(exportState, 'sea_surface_slope_zonal', &
+       isc, iec, jsc, jec, dhdx_rot, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  call State_SetExport(exportState, 'sea_surface_slope_merid', &
+       isc, iec, jsc, jec, dhdy_rot, ocean_grid, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return  ! bail out
+
+  deallocate(ssh, dhdx, dhdy, dhdx_rot, dhdy_rot)
+
+end subroutine mom_export
 
 !===============================================================================
 
-  subroutine State_GetFldPtr_2d(State, fldname, fldptr, rc)
-    type(ESMF_State)            , intent(in)  :: State
-    character(len=*)            , intent(in)  :: fldname
-    real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:,:)
-    integer, optional           , intent(out) :: rc
+subroutine State_GetFldPtr_1d(State, fldname, fldptr, rc)
+  type(ESMF_State)            , intent(in)  :: State
+  character(len=*)            , intent(in)  :: fldname
+  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:)
+  integer, optional           , intent(out) :: rc
 
-    ! local variables
-    type(ESMF_Field) :: lfield
-    integer :: lrc
-    character(len=*),parameter :: subname='(mom_cap:State_GetFldPtr)'
+  ! local variables
+  type(ESMF_Field) :: lfield
+  integer :: lrc
+  character(len=*),parameter :: subname='(mom_cap:State_GetFldPtr)'
 
-    call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_FieldGet(lfield, farrayPtr=fldptr, rc=lrc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=lrc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call ESMF_FieldGet(lfield, farrayPtr=fldptr, rc=lrc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    if (present(rc)) rc = lrc
+  if (present(rc)) rc = lrc
 
-  end subroutine State_GetFldPtr_2d
+end subroutine State_GetFldPtr_1d
 
-  !===============================================================================
+!===============================================================================
 
-  subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, rc)
+subroutine State_GetFldPtr_2d(State, fldname, fldptr, rc)
+  type(ESMF_State)            , intent(in)  :: State
+  character(len=*)            , intent(in)  :: fldname
+  real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:,:)
+  integer, optional           , intent(out) :: rc
 
-    ! ----------------------------------------------
-    ! Map import state field to output array
-    ! ----------------------------------------------
+  ! local variables
+  type(ESMF_Field) :: lfield
+  integer :: lrc
+  character(len=*),parameter :: subname='(mom_cap:State_GetFldPtr)'
 
-    ! input/output variables
-    type(ESMF_State)    , intent(in)    :: state
-    character(len=*)    , intent(in)    :: fldname
-    integer             , intent(in)    :: isc
-    integer             , intent(in)    :: iec
-    integer             , intent(in)    :: jsc
-    integer             , intent(in)    :: jec
-    real (ESMF_KIND_R8) , intent(inout) :: output(isc:iec,jsc:jec)
-    logical, optional   , intent(in)    :: do_sum
-    integer             , intent(out)   :: rc
+  call ESMF_StateGet(State, itemName=trim(fldname), field=lfield, rc=lrc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
+  call ESMF_FieldGet(lfield, farrayPtr=fldptr, rc=lrc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    ! local variables
-    type(ESMF_StateItem_Flag)     :: itemFlag
-    integer                       :: n, i, j, i1, j1
-    integer                       :: lbnd1,lbnd2
-    real(ESMF_KIND_R8), pointer   :: dataPtr1d(:)
-    real(ESMF_KIND_R8), pointer   :: dataPtr2d(:,:)
-    character(len=*)  , parameter :: subname='(mom_cap_methods:state_getimport)'
-    ! ----------------------------------------------
+  if (present(rc)) rc = lrc
 
-    rc = ESMF_SUCCESS
+end subroutine State_GetFldPtr_2d
 
-    call ESMF_StateGet(State, trim(fldname), itemFlag, rc=rc)
-    if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
+!===============================================================================
 
-       if (geomtype == ESMF_GEOMTYPE_MESH) then
+subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, rc)
 
-          ! get field pointer
-          call state_getfldptr(state, trim(fldname), dataptr1d, rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
+  ! ----------------------------------------------
+  ! Map import state field to output array
+  ! ----------------------------------------------
 
-          ! determine output array
-          n = 0
-          do j = jsc,jec
-             do i = isc,iec
-                n = n + 1
-                if (present(do_sum)) then
-                   output(i,j)  = output(i,j) + dataPtr1d(n)
-                else
-                   output(i,j)  = dataPtr1d(n)
-                end if
-             end do
-          end do
+  ! input/output variables
+  type(ESMF_State)    , intent(in)    :: state
+  character(len=*)    , intent(in)    :: fldname
+  integer             , intent(in)    :: isc
+  integer             , intent(in)    :: iec
+  integer             , intent(in)    :: jsc
+  integer             , intent(in)    :: jec
+  real (ESMF_KIND_R8) , intent(inout) :: output(isc:iec,jsc:jec)
+  logical, optional   , intent(in)    :: do_sum
+  integer             , intent(out)   :: rc
 
-       else if (geomtype == ESMF_GEOMTYPE_GRID) then
+  ! local variables
+  type(ESMF_StateItem_Flag)     :: itemFlag
+  integer                       :: n, i, j, i1, j1
+  integer                       :: lbnd1,lbnd2
+  real(ESMF_KIND_R8), pointer   :: dataPtr1d(:)
+  real(ESMF_KIND_R8), pointer   :: dataPtr2d(:,:)
+  character(len=*)  , parameter :: subname='(mom_cap_methods:state_getimport)'
+  ! ----------------------------------------------
 
-          call state_getfldptr(state, trim(fldname), dataptr2d, rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
+  rc = ESMF_SUCCESS
 
-          lbnd1 = lbound(dataPtr2d,1)
-          lbnd2 = lbound(dataPtr2d,2)
+  call ESMF_StateGet(State, trim(fldname), itemFlag, rc=rc)
+  if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
 
-          do j = jsc, jec
-             j1 = j + lbnd2 - jsc
-             do i = isc, iec
-                i1 = i + lbnd1 - isc
-                if (present(do_sum)) then
-                   output(i,j) = output(i,j) + dataPtr2d(i1,j1)
-                else
-                   output(i,j) = dataPtr2d(i1,j1)
-                end if
-             end do
-          end do
+     if (geomtype == ESMF_GEOMTYPE_MESH) then
 
-       end if
+	! get field pointer
+	call state_getfldptr(state, trim(fldname), dataptr1d, rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
 
-    end if
+	! determine output array
+	n = 0
+	do j = jsc,jec
+	   do i = isc,iec
+	      n = n + 1
+	      if (present(do_sum)) then
+		 output(i,j)  = output(i,j) + dataPtr1d(n)
+	      else
+		 output(i,j)  = dataPtr1d(n)
+	      end if
+	   end do
+	end do
 
-  end subroutine State_GetImport
+     else if (geomtype == ESMF_GEOMTYPE_GRID) then
 
-  !===============================================================================
+	call state_getfldptr(state, trim(fldname), dataptr2d, rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
 
-  subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid, rc)
+	lbnd1 = lbound(dataPtr2d,1)
+	lbnd2 = lbound(dataPtr2d,2)
 
-    ! ----------------------------------------------
-    ! Map input array to export state
-    ! ----------------------------------------------
+	do j = jsc, jec
+	   j1 = j + lbnd2 - jsc
+	   do i = isc, iec
+	      i1 = i + lbnd1 - isc
+	      if (present(do_sum)) then
+		 output(i,j) = output(i,j) + dataPtr2d(i1,j1)
+	      else
+		 output(i,j) = dataPtr2d(i1,j1)
+	      end if
+	   end do
+	end do
 
-    ! input/output variables
-    type(ESMF_State)      , intent(inout) :: state
-    character(len=*)      , intent(in)    :: fldname
-    integer               , intent(in)    :: isc
-    integer               , intent(in)    :: iec
-    integer               , intent(in)    :: jsc
-    integer               , intent(in)    :: jec
-    real (ESMF_KIND_R8)   , intent(in)    :: input(isc:iec,jsc:jec)
-    type(ocean_grid_type) , intent(in)    :: ocean_grid
-    integer               , intent(out)   :: rc
+     end if
 
-    ! local variables
-    type(ESMF_StateItem_Flag)     :: itemFlag
-    integer                       :: n, i, j, i1, j1, ig,jg
-    integer                       :: lbnd1,lbnd2
-    real(ESMF_KIND_R8), pointer   :: dataPtr1d(:)
-    real(ESMF_KIND_R8), pointer   :: dataPtr2d(:,:)
-    character(len=*)  , parameter :: subname='(mom_cap_methods:state_setexport)'
-    ! ----------------------------------------------
+  end if
 
-    rc = ESMF_SUCCESS
+end subroutine State_GetImport
 
-    ! Indexing notes:
-    ! input array from "ocean_public" uses local indexing without halos
-    ! mask from "ocean_grid" uses local indexing with halos
+!===============================================================================
 
-    call ESMF_StateGet(State, trim(fldname), itemFlag, rc=rc)
-    if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
+subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid, rc)
 
-       if (geomtype == ESMF_GEOMTYPE_MESH) then
+  ! ----------------------------------------------
+  ! Map input array to export state
+  ! ----------------------------------------------
 
-          call state_getfldptr(state, trim(fldname), dataptr1d, rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
+  ! input/output variables
+  type(ESMF_State)      , intent(inout) :: state
+  character(len=*)      , intent(in)    :: fldname
+  integer               , intent(in)    :: isc
+  integer               , intent(in)    :: iec
+  integer               , intent(in)    :: jsc
+  integer               , intent(in)    :: jec
+  real (ESMF_KIND_R8)   , intent(in)    :: input(isc:iec,jsc:jec)
+  type(ocean_grid_type) , intent(in)    :: ocean_grid
+  integer               , intent(out)   :: rc
 
-          n = 0
-          do j = jsc, jec
-             jg = j + ocean_grid%jsc - jsc
-             do i = isc, iec
-                ig = i + ocean_grid%isc - isc
-                n = n+1
-                dataPtr1d(n) = input(i,j) * ocean_grid%mask2dT(ig,jg)
-             end do
-          end do
+  ! local variables
+  type(ESMF_StateItem_Flag)     :: itemFlag
+  integer                       :: n, i, j, i1, j1, ig,jg
+  integer                       :: lbnd1,lbnd2
+  real(ESMF_KIND_R8), pointer   :: dataPtr1d(:)
+  real(ESMF_KIND_R8), pointer   :: dataPtr2d(:,:)
+  character(len=*)  , parameter :: subname='(mom_cap_methods:state_setexport)'
+  ! ----------------------------------------------
 
-       else if (geomtype == ESMF_GEOMTYPE_GRID) then
+  rc = ESMF_SUCCESS
 
-          call state_getfldptr(state, trim(fldname), dataptr2d, rc)
-          if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-               line=__LINE__, &
-               file=__FILE__)) &
-               return  ! bail out
+  ! Indexing notes:
+  ! input array from "ocean_public" uses local indexing without halos
+  ! mask from "ocean_grid" uses local indexing with halos
 
-          lbnd1 = lbound(dataPtr2d,1)
-          lbnd2 = lbound(dataPtr2d,2)
+  call ESMF_StateGet(State, trim(fldname), itemFlag, rc=rc)
+  if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
 
-          do j = jsc, jec
-             j1 = j + lbnd2 - jsc
-             jg = j + ocean_grid%jsc - jsc
-             do i = isc, iec
-                i1 = i + lbnd1 - isc
-                ig = i + ocean_grid%isc - isc
-                dataPtr2d(i1,j1)  = input(i,j) * ocean_grid%mask2dT(ig,jg)
-             end do
-          end do
+     if (geomtype == ESMF_GEOMTYPE_MESH) then
 
-       end if
+	call state_getfldptr(state, trim(fldname), dataptr1d, rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
 
-    end if
+	n = 0
+	do j = jsc, jec
+	   jg = j + ocean_grid%jsc - jsc
+	   do i = isc, iec
+	      ig = i + ocean_grid%isc - isc
+	      n = n+1
+	      dataPtr1d(n) = input(i,j) * ocean_grid%mask2dT(ig,jg)
+	   end do
+	end do
 
-  end subroutine State_SetExport
+     else if (geomtype == ESMF_GEOMTYPE_GRID) then
+
+	call state_getfldptr(state, trim(fldname), dataptr2d, rc)
+	if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	     line=__LINE__, &
+	     file=__FILE__)) &
+	     return  ! bail out
+
+	lbnd1 = lbound(dataPtr2d,1)
+	lbnd2 = lbound(dataPtr2d,2)
+
+	do j = jsc, jec
+	   j1 = j + lbnd2 - jsc
+	   jg = j + ocean_grid%jsc - jsc
+	   do i = isc, iec
+	      i1 = i + lbnd1 - isc
+	      ig = i + ocean_grid%isc - isc
+	      dataPtr2d(i1,j1)  = input(i,j) * ocean_grid%mask2dT(ig,jg)
+	   end do
+	end do
+
+     end if
+
+  end if
+
+end subroutine State_SetExport
 
 end module mom_cap_methods

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -65,7 +65,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
   type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
   type(ice_ocean_boundary_type) , intent(inout) :: ice_ocean_boundary !< Ocean boundary forcing
   character(len=*), optional    , intent(in)    :: runtype            !< For cesm only, type of run
-  integer                       , intent(inout) :: rc                 !< Error handler
+  integer                       , intent(inout) :: rc                 !< Return code
 
   ! Local Variables
   integer                         :: i, j, ig, jg, n
@@ -350,7 +350,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
   type(ocean_state_type)  , pointer       :: ocean_state  !< Ocean state
   type(ESMF_State)        , intent(inout) :: exportState  !< outgoing data
   type(ESMF_Clock)        , intent(in)    :: clock        !< ESMF clock
-  integer                 , intent(inout) :: rc           !< Error handler
+  integer                 , intent(inout) :: rc           !< Return code
 
   ! Local variables
   integer                         :: i, j, ig, jg         ! indices
@@ -658,7 +658,7 @@ subroutine State_GetFldPtr_1d(State, fldname, fldptr, rc)
   type(ESMF_State)            , intent(in)  :: State    !< ESMF state
   character(len=*)            , intent(in)  :: fldname  !< Field name
   real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:)!< Pointer to the 1D field
-  integer, optional           , intent(out) :: rc       !< Error handler
+  integer, optional           , intent(out) :: rc       !< Return code
 
   ! local variables
   type(ESMF_Field) :: lfield
@@ -685,7 +685,7 @@ subroutine State_GetFldPtr_2d(State, fldname, fldptr, rc)
   type(ESMF_State)            , intent(in)  :: State      !< ESMF state
   character(len=*)            , intent(in)  :: fldname    !< Field name
   real(ESMF_KIND_R8), pointer , intent(in)  :: fldptr(:,:)!< Pointer to the 2D field
-  integer, optional           , intent(out) :: rc         !< Error handler
+  integer, optional           , intent(out) :: rc         !< Return code
 
   ! local variables
   type(ESMF_Field) :: lfield
@@ -721,7 +721,7 @@ subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, r
                                                  !! the computational domain
   real (ESMF_KIND_R8) , intent(inout) :: output(isc:iec,jsc:jec)!< Output 2D array
   logical, optional   , intent(in)    :: do_sum  !< If true, sums the data
-  integer             , intent(out)   :: rc      !< Error handler
+  integer             , intent(out)   :: rc      !< Return code
 
   ! local variables
   type(ESMF_StateItem_Flag)     :: itemFlag
@@ -802,7 +802,7 @@ subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid
                                                    !! the computational domain
   real (ESMF_KIND_R8)   , intent(in)    :: input(isc:iec,jsc:jec)!< Input 2D array
   type(ocean_grid_type) , intent(in)    :: ocean_grid !< Ocean horizontal grid
-  integer               , intent(out)   :: rc         !< Error handler
+  integer               , intent(out)   :: rc         !< Return code
 
   ! local variables
   type(ESMF_StateItem_Flag)     :: itemFlag

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -58,8 +58,6 @@ end subroutine mom_set_geomtype
 !! (1) it imports surface fluxes using data from the mediator; and
 !! (2) it can apply restoring in SST and SSS.
 subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary, runtype, rc)
-
-  ! Input/output variables
   type(ocean_public_type)       , intent(in)    :: ocean_public       !< Ocean surface state
   type(ocean_grid_type)         , intent(in)    :: ocean_grid         !< Ocean model grid
   type(ESMF_State)              , intent(inout) :: importState        !< incoming data from mediator
@@ -343,8 +341,6 @@ end subroutine mom_import
 
 !> Maps outgoing ocean data to ESMF State
 subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock, rc)
-
-  ! Input/output variables
   type(ocean_public_type) , intent(in)    :: ocean_public !< Ocean surface state
   type(ocean_grid_type)   , intent(in)    :: ocean_grid   !< Ocean model grid
   type(ocean_state_type)  , pointer       :: ocean_state  !< Ocean state

--- a/config_src/nuopc_driver/mom_cap_methods.F90
+++ b/config_src/nuopc_driver/mom_cap_methods.F90
@@ -86,10 +86,10 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
         do_import = .false. ! This will skip the first time import information is given
      else
         do_import = .true.
-     end if
+     endif
   else
      do_import = .true.
-  end if
+  endif
 
   if (do_import) then
      ! The following are global indices without halos
@@ -182,8 +182,8 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
 					  - ocean_grid%sin_rot(ig,jg)*tauy(i,j)
 	   ice_ocean_boundary%v_flux(i,j) = ocean_grid%cos_rot(ig,jg)*tauy(i,j) &
 					  + ocean_grid%sin_rot(ig,jg)*taux(i,j)
-	end do
-     end do
+	enddo
+     enddo
 
      deallocate(taux, tauy)
 
@@ -335,7 +335,7 @@ subroutine mom_import(ocean_public, ocean_grid, importState, ice_ocean_boundary,
          file=__FILE__)) &
          return  ! bail out
 
-  end if
+  endif
 
 end subroutine mom_import
 
@@ -390,7 +390,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
      inv_dt_int = 1.0 / real(dt_int)
   else
      inv_dt_int = 0.0
-  end if
+  endif
 
   !----------------
   ! Copy from ocean_public to exportstate.
@@ -460,8 +460,8 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	ocm(i,j) = ocean_public%v_surf(i,j)
 	ocz_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocz(i,j) + ocean_grid%sin_rot(ig,jg)*ocm(i,j)
 	ocm_rot(i,j) = ocean_grid%cos_rot(ig,jg)*ocm(i,j) - ocean_grid%sin_rot(ig,jg)*ocz(i,j)
-     end do
-  end do
+     enddo
+  enddo
 
   call State_SetExport(exportState, 'ocn_current_zonal', &
        isc, iec, jsc, jec, ocz_rot, ocean_grid, rc=rc)
@@ -490,7 +490,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	  line=__LINE__, &
 	  file=__FILE__)) &
 	  return  ! bail out
-  end if
+  endif
 
   ! -------
   ! Freezing melting potential
@@ -507,9 +507,9 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	else
 	   melt_potential(i,j) = -ocean_public%melt_potential(i,j) * inv_dt_int
 	   if (melt_potential(i,j) > 0.0) melt_potential(i,j) = 0.0
-	end if
-     end do
-  end do
+	endif
+     enddo
+  enddo
 
   call State_SetExport(exportState, 'freezing_melting_potential', &
        isc, iec, jsc, jec, melt_potential, ocean_grid, rc=rc)
@@ -531,7 +531,7 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	  line=__LINE__, &
 	  file=__FILE__)) &
 	  return  ! bail out
-  end if
+  endif
 
   !----------------
   ! Sea-surface zonal and meridional slopes
@@ -553,8 +553,8 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
      do i = ocean_grid%isc,ocean_grid%iec
 	iloc = i + ocean_grid%idg_offset
 	ssh(i,j) = ocean_public%sea_lev(iloc,jloc)
-     end do
-  end do
+     enddo
+  enddo
 
   ! Update halo of ssh so we can calculate gradients (local indexing)
   call pass_var(ssh, ocean_grid%domain)
@@ -583,11 +583,11 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	! Extrema in the mean values require a PCM reconstruction avoid generating
 	! larger extreme values.
 	slope = 0.0
-      end if
+      endif
       dhdx(iglob,jglob) = slope * ocean_grid%IdxT(i,j) * ocean_grid%mask2dT(i,j)
       if (ocean_grid%mask2dT(i,j)==0.) dhdx(iglob,jglob) = 0.0
-    end do
-  end do
+    enddo
+  enddo
 
   ! d/dy ssh
   ! This is a simple second-order difference
@@ -613,11 +613,11 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	! Extrema in the mean values require a PCM reconstruction avoid generating
 	! larger extreme values.
 	slope = 0.0
-      end if
+      endif
       dhdy(iglob,jglob) = slope * ocean_grid%IdyT(i,j) * ocean_grid%mask2dT(i,j)
       if (ocean_grid%mask2dT(i,j)==0.) dhdy(iglob,jglob) = 0.0
-    end do
-  end do
+    enddo
+  enddo
 
   ! rotate slopes from tripolar grid back to lat/lon grid,  x,y => latlon (CCW)
   ! "ocean_grid" uses has halos and uses local indexing.
@@ -628,8 +628,8 @@ subroutine mom_export(ocean_public, ocean_grid, ocean_state, exportState, clock,
 	ig = i + ocean_grid%isc - isc
 	dhdx_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdx(i,j) + ocean_grid%sin_rot(ig,jg)*dhdy(i,j)
 	dhdy_rot(i,j) = ocean_grid%cos_rot(ig,jg)*dhdy(i,j) - ocean_grid%sin_rot(ig,jg)*dhdx(i,j)
-     end do
-  end do
+     enddo
+  enddo
 
   call State_SetExport(exportState, 'sea_surface_slope_zonal', &
        isc, iec, jsc, jec, dhdx_rot, ocean_grid, rc=rc)
@@ -751,9 +751,9 @@ subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, r
 		 output(i,j)  = output(i,j) + dataPtr1d(n)
 	      else
 		 output(i,j)  = dataPtr1d(n)
-	      end if
-	   end do
-	end do
+	      endif
+	   enddo
+	enddo
 
      else if (geomtype == ESMF_GEOMTYPE_GRID) then
 
@@ -774,13 +774,13 @@ subroutine State_GetImport(state, fldname, isc, iec, jsc, jec, output, do_sum, r
 		 output(i,j) = output(i,j) + dataPtr2d(i1,j1)
 	      else
 		 output(i,j) = dataPtr2d(i1,j1)
-	      end if
-	   end do
-	end do
+	      endif
+	   enddo
+	enddo
 
-     end if
+     endif
 
-  end if
+  endif
 
 end subroutine State_GetImport
 
@@ -833,8 +833,8 @@ subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid
 	      ig = i + ocean_grid%isc - isc
 	      n = n+1
 	      dataPtr1d(n) = input(i,j) * ocean_grid%mask2dT(ig,jg)
-	   end do
-	end do
+	   enddo
+	enddo
 
      else if (geomtype == ESMF_GEOMTYPE_GRID) then
 
@@ -854,12 +854,12 @@ subroutine State_SetExport(state, fldname, isc, iec, jsc, jec, input, ocean_grid
 	      i1 = i + lbnd1 - isc
 	      ig = i + ocean_grid%isc - isc
 	      dataPtr2d(i1,j1)  = input(i,j) * ocean_grid%mask2dT(ig,jg)
-	   end do
-	end do
+	   enddo
+	enddo
 
-     end if
+     endif
 
-  end if
+  endif
 
 end subroutine State_SetExport
 

--- a/config_src/nuopc_driver/mom_cap_time.F90
+++ b/config_src/nuopc_driver/mom_cap_time.F90
@@ -114,14 +114,14 @@ subroutine AlarmInit( clock, alarm, option, &
 	     line=__LINE__, &
 	     file=__FILE__, rcToReturn=rc)
 	return
-     end if
+     endif
      if (opt_n <= 0) then
 	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
 	     msg=subname//trim(option)//' invalid opt_n', &
 	     line=__LINE__, &
 	     file=__FILE__, rcToReturn=rc)
 	return
-     end if
+     endif
   endif
 
   call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
@@ -179,14 +179,14 @@ subroutine AlarmInit( clock, alarm, option, &
 	     line=__LINE__, &
 	     file=__FILE__, rcToReturn=rc)
 	return
-     end if
+     endif
      if (lymd < 0 .or. ltod < 0) then
 	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
 	     msg=subname//trim(option)//'opt_ymd, opt_tod invalid', &
 	     line=__LINE__, &
 	     file=__FILE__, rcToReturn=rc)
 	return
-     end if
+     endif
      call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
 	  line=__LINE__, &
@@ -206,7 +206,7 @@ subroutine AlarmInit( clock, alarm, option, &
 	     line=__LINE__, &
 	     file=__FILE__, rcToReturn=rc)
 	return
-     end if
+     endif
      call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
 	  line=__LINE__, &
@@ -367,13 +367,13 @@ subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
      if (present(logunit)) then
 	write(logunit,*) subname//': ERROR yymmdd is a negative number or '// &
 	     'time-of-day out of bounds', ymd, ltod
-     end if
+     endif
      call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
 	  msg=subname//' yymmdd is negative or time-of-day out of bounds ', &
 	  line=__LINE__, &
 	  file=__FILE__, rcToReturn=rc)
      return
-  end if
+  endif
 
   call date2ymd (ymd,yr,mon,day)
 
@@ -399,7 +399,7 @@ subroutine date2ymd (date, year, month, day)
   year = int(tdate/10000)
   if (date < 0) then
      year = -year
-  end if
+  endif
   month = int( mod(tdate,10000)/  100)
   day = mod(tdate,  100)
 

--- a/config_src/nuopc_driver/mom_cap_time.F90
+++ b/config_src/nuopc_driver/mom_cap_time.F90
@@ -8,418 +8,417 @@
 !
 module mom_cap_time
 
-  ! !USES:
-  use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm
-  use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
-  use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
-  use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate
-  use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
-  use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
-  use ESMF                  , only : ESMF_RC_ARG_BAD
-  use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
-  use ESMF                  , only : operator(<=), operator(>), operator(==)
+! !USES:
+use ESMF                  , only : ESMF_Time, ESMF_Clock, ESMF_Calendar, ESMF_Alarm
+use ESMF                  , only : ESMF_TimeGet, ESMF_TimeSet
+use ESMF                  , only : ESMF_TimeInterval, ESMF_TimeIntervalSet
+use ESMF                  , only : ESMF_ClockGet, ESMF_AlarmCreate
+use ESMF                  , only : ESMF_SUCCESS, ESMF_LogWrite, ESMF_LOGMSG_INFO
+use ESMF                  , only : ESMF_LogSetError, ESMF_LogFoundError, ESMF_LOGERR_PASSTHRU
+use ESMF                  , only : ESMF_RC_ARG_BAD
+use ESMF                  , only : operator(<), operator(/=), operator(+), operator(-), operator(*) , operator(>=)
+use ESMF                  , only : operator(<=), operator(>), operator(==)
 
-  implicit none
-  private    ! default private
+implicit none; private
 
-  public  :: AlarmInit  ! initialize an alarm
+public  :: AlarmInit  ! initialize an alarm
 
-  private :: TimeInit
-  private :: date2ymd
+private :: TimeInit
+private :: date2ymd
 
-  ! Clock and alarm options
-  character(len=*), private, parameter :: &
-       optNONE           = "none"      , &
-       optNever          = "never"     , &
-       optNSteps         = "nsteps"    , &
-       optNStep          = "nstep"     , &
-       optNSeconds       = "nseconds"  , &
-       optNSecond        = "nsecond"   , &
-       optNMinutes       = "nminutes"  , &
-       optNMinute        = "nminute"   , &
-       optNHours         = "nhours"    , &
-       optNHour          = "nhour"     , &
-       optNDays          = "ndays"     , &
-       optNDay           = "nday"      , &
-       optNMonths        = "nmonths"   , &
-       optNMonth         = "nmonth"    , &
-       optNYears         = "nyears"    , &
-       optNYear          = "nyear"     , &
-       optMonthly        = "monthly"   , &
-       optYearly         = "yearly"    , &
-       optDate           = "date"      , &
-       optIfdays0        = "ifdays0"   , &
-       optGLCCouplingPeriod = "glc_coupling_period"
+! Clock and alarm options
+character(len=*), private, parameter :: &
+     optNONE           = "none"      , &
+     optNever          = "never"     , &
+     optNSteps         = "nsteps"    , &
+     optNStep          = "nstep"     , &
+     optNSeconds       = "nseconds"  , &
+     optNSecond        = "nsecond"   , &
+     optNMinutes       = "nminutes"  , &
+     optNMinute        = "nminute"   , &
+     optNHours         = "nhours"    , &
+     optNHour          = "nhour"     , &
+     optNDays          = "ndays"     , &
+     optNDay           = "nday"      , &
+     optNMonths        = "nmonths"   , &
+     optNMonth         = "nmonth"    , &
+     optNYears         = "nyears"    , &
+     optNYear          = "nyear"     , &
+     optMonthly        = "monthly"   , &
+     optYearly         = "yearly"    , &
+     optDate           = "date"      , &
+     optIfdays0        = "ifdays0"   , &
+     optGLCCouplingPeriod = "glc_coupling_period"
 
-  ! Module data
-  integer, parameter          :: SecPerDay = 86400 ! Seconds per day
-  character(len=*), parameter :: u_FILE_u = &
-       __FILE__
+! Module data
+integer, parameter          :: SecPerDay = 86400 ! Seconds per day
+character(len=*), parameter :: u_FILE_u = &
+     __FILE__
 
 !===============================================================================
 contains
 !===============================================================================
 
-  subroutine AlarmInit( clock, alarm, option, &
-       opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
+subroutine AlarmInit( clock, alarm, option, &
+     opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
 
-    ! !DESCRIPTION: Setup an alarm in a clock
-    ! Notes: The ringtime sent to AlarmCreate MUST be the next alarm
-    ! time.  If you send an arbitrary but proper ringtime from the
-    ! past and the ring interval, the alarm will always go off on the
-    ! next clock advance and this will cause serious problems.  Even
-    ! if it makes sense to initialize an alarm with some reference
-    ! time and the alarm interval, that reference time has to be
-    ! advance forward to be >= the current time.  In the logic below
-    ! we set an appropriate "NextAlarm" and then we make sure to
-    ! advance it properly based on the ring interval.
+  ! !DESCRIPTION: Setup an alarm in a clock
+  ! Notes: The ringtime sent to AlarmCreate MUST be the next alarm
+  ! time.  If you send an arbitrary but proper ringtime from the
+  ! past and the ring interval, the alarm will always go off on the
+  ! next clock advance and this will cause serious problems.  Even
+  ! if it makes sense to initialize an alarm with some reference
+  ! time and the alarm interval, that reference time has to be
+  ! advance forward to be >= the current time.  In the logic below
+  ! we set an appropriate "NextAlarm" and then we make sure to
+  ! advance it properly based on the ring interval.
 
-    ! input/output variables
-    type(ESMF_Clock)            , intent(inout) :: clock     ! clock
-    type(ESMF_Alarm)            , intent(inout) :: alarm     ! alarm
-    character(len=*)            , intent(in)    :: option    ! alarm option
-    integer          , optional , intent(in)    :: opt_n     ! alarm freq
-    integer          , optional , intent(in)    :: opt_ymd   ! alarm ymd
-    integer          , optional , intent(in)    :: opt_tod   ! alarm tod (sec)
-    type(ESMF_Time)  , optional , intent(in)    :: RefTime   ! ref time
-    character(len=*) , optional , intent(in)    :: alarmname ! alarm name
-    integer                     , intent(inout) :: rc        ! Return code
+  ! input/output variables
+  type(ESMF_Clock)            , intent(inout) :: clock     ! clock
+  type(ESMF_Alarm)            , intent(inout) :: alarm     ! alarm
+  character(len=*)            , intent(in)    :: option    ! alarm option
+  integer          , optional , intent(in)    :: opt_n     ! alarm freq
+  integer          , optional , intent(in)    :: opt_ymd   ! alarm ymd
+  integer          , optional , intent(in)    :: opt_tod   ! alarm tod (sec)
+  type(ESMF_Time)  , optional , intent(in)    :: RefTime   ! ref time
+  character(len=*) , optional , intent(in)    :: alarmname ! alarm name
+  integer                     , intent(inout) :: rc        ! Return code
 
-    ! local variables
-    type(ESMF_Calendar)     :: cal                ! calendar
-    integer                 :: lymd             ! local ymd
-    integer                 :: ltod             ! local tod
-    integer                 :: cyy,cmm,cdd,csec ! time info
-    integer                 :: nyy,nmm,ndd,nsec ! time info
-    character(len=64)       :: lalarmname       ! local alarm name
-    logical                 :: update_nextalarm ! update next alarm
-    type(ESMF_Time)         :: CurrTime         ! Current Time
-    type(ESMF_Time)         :: NextAlarm        ! Next restart alarm time
-    type(ESMF_TimeInterval) :: AlarmInterval    ! Alarm interval
-    character(len=*), parameter :: subname = '(AlarmInit): '
-    !-------------------------------------------------------------------------------
+  ! local variables
+  type(ESMF_Calendar)     :: cal                ! calendar
+  integer                 :: lymd             ! local ymd
+  integer                 :: ltod             ! local tod
+  integer                 :: cyy,cmm,cdd,csec ! time info
+  integer                 :: nyy,nmm,ndd,nsec ! time info
+  character(len=64)       :: lalarmname       ! local alarm name
+  logical                 :: update_nextalarm ! update next alarm
+  type(ESMF_Time)         :: CurrTime         ! Current Time
+  type(ESMF_Time)         :: NextAlarm        ! Next restart alarm time
+  type(ESMF_TimeInterval) :: AlarmInterval    ! Alarm interval
+  character(len=*), parameter :: subname = '(AlarmInit): '
+  !-------------------------------------------------------------------------------
 
-    rc = ESMF_SUCCESS
+  rc = ESMF_SUCCESS
 
-    lalarmname = 'alarm_unknown'
-    if (present(alarmname)) lalarmname = trim(alarmname)
-    ltod = 0
-    if (present(opt_tod)) ltod = opt_tod
-    lymd = -1
-    if (present(opt_ymd)) lymd = opt_ymd
+  lalarmname = 'alarm_unknown'
+  if (present(alarmname)) lalarmname = trim(alarmname)
+  ltod = 0
+  if (present(opt_tod)) ltod = opt_tod
+  lymd = -1
+  if (present(opt_ymd)) lymd = opt_ymd
 
-    ! verify parameters
-    if (trim(option) == optNSteps    .or. trim(option) == optNStep   .or. &
-        trim(option) == optNSeconds  .or. trim(option) == optNSecond .or. &
-        trim(option) == optNMinutes  .or. trim(option) == optNMinute .or. &
-        trim(option) == optNHours    .or. trim(option) == optNHour   .or. &
-        trim(option) == optNDays     .or. trim(option) == optNDay    .or. &
-        trim(option) == optNMonths   .or. trim(option) == optNMonth  .or. &
-        trim(option) == optNYears    .or. trim(option) == optNYear   .or. &
-        trim(option) == optIfdays0) then
-       if (.not. present(opt_n)) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//trim(option)//' requires opt_n', &
-               line=__LINE__, &
-               file=__FILE__, rcToReturn=rc)
-          return
-       end if
-       if (opt_n <= 0) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//trim(option)//' invalid opt_n', &
-               line=__LINE__, &
-               file=__FILE__, rcToReturn=rc)
-          return
-       end if
-    endif
+  ! verify parameters
+  if (trim(option) == optNSteps    .or. trim(option) == optNStep   .or. &
+      trim(option) == optNSeconds  .or. trim(option) == optNSecond .or. &
+      trim(option) == optNMinutes  .or. trim(option) == optNMinute .or. &
+      trim(option) == optNHours    .or. trim(option) == optNHour   .or. &
+      trim(option) == optNDays     .or. trim(option) == optNDay    .or. &
+      trim(option) == optNMonths   .or. trim(option) == optNMonth  .or. &
+      trim(option) == optNYears    .or. trim(option) == optNYear   .or. &
+      trim(option) == optIfdays0) then
+     if (.not. present(opt_n)) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//trim(option)//' requires opt_n', &
+	     line=__LINE__, &
+	     file=__FILE__, rcToReturn=rc)
+	return
+     end if
+     if (opt_n <= 0) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//trim(option)//' invalid opt_n', &
+	     line=__LINE__, &
+	     file=__FILE__, rcToReturn=rc)
+	return
+     end if
+  endif
 
-    call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return
+  call ESMF_ClockGet(clock, CurrTime=CurrTime, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return
 
-    call ESMF_TimeGet(CurrTime, yy=cyy, mm=cmm, dd=cdd, s=csec, rc=rc )
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-
-    call ESMF_TimeGet(CurrTime, yy=nyy, mm=nmm, dd=ndd, s=nsec, rc=rc )
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-
-    ! initial guess of next alarm, this will be updated below
-    if (present(RefTime)) then
-       NextAlarm = RefTime
-    else
-       NextAlarm = CurrTime
-    endif
-
-    ! Determine calendar
-    call ESMF_ClockGet(clock, calendar=cal, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-
-    ! Determine inputs for call to create alarm
-    selectcase (trim(option))
-
-    case (optNONE, optNever)
-       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       update_nextalarm  = .false.
-
-    case (optDate)
-       if (.not. present(opt_ymd)) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//trim(option)//' requires opt_ymd', &
-               line=__LINE__, &
-               file=__FILE__, rcToReturn=rc)
-          return
-       end if
-       if (lymd < 0 .or. ltod < 0) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//trim(option)//'opt_ymd, opt_tod invalid', &
-               line=__LINE__, &
-               file=__FILE__, rcToReturn=rc)
-          return
-       end if
-       call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call TimeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate", rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       update_nextalarm  = .false.
-
-    case (optIfdays0)
-       if (.not. present(opt_ymd)) then
-          call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-               msg=subname//trim(option)//' requires opt_ymd', &
-               line=__LINE__, &
-               file=__FILE__, rcToReturn=rc)
-          return
-       end if
-       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=opt_n, s=0, calendar=cal, rc=rc )
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       update_nextalarm  = .true.
-
-    case (optNSteps, optNStep)
-       call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optNSeconds, optNSecond)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optNMinutes, optNMinute)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optNHours, optNHour)
-       call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optNDays, optNDay)
-       call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optNMonths, optNMonth)
-       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optMonthly)
-       call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=1, s=0, calendar=cal, rc=rc )
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       update_nextalarm  = .true.
-
-    case (optNYears, optNYear)
-       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       AlarmInterval = AlarmInterval * opt_n
-       update_nextalarm  = .true.
-
-    case (optYearly)
-       call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
-       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-            line=__LINE__, &
-            file=__FILE__)) &
-            return
-       update_nextalarm  = .true.
-
-    case default
-       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-            msg=subname//' unknown option: '//trim(option), &
-            line=__LINE__, &
-            file=__FILE__, rcToReturn=rc)
+  call ESMF_TimeGet(CurrTime, yy=cyy, mm=cmm, dd=cdd, s=csec, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
        return
 
-    end select
-
-    ! --------------------------------------------------------------------------------
-    ! --- AlarmInterval and NextAlarm should be set ---
-    ! --------------------------------------------------------------------------------
-
-    ! --- advance Next Alarm so it won't ring on first timestep for
-    ! --- most options above. go back one alarminterval just to be careful
-
-    if (update_nextalarm) then
-       NextAlarm = NextAlarm - AlarmInterval
-       do while (NextAlarm <= CurrTime)
-          NextAlarm = NextAlarm + AlarmInterval
-       enddo
-    endif
-
-    alarm = ESMF_AlarmCreate( name=lalarmname, clock=clock, ringTime=NextAlarm, ringInterval=AlarmInterval, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
-
-  end subroutine AlarmInit
-
-  !===============================================================================
-
-  subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
-
-    !  Create the ESMF_Time object corresponding to the given input time, given in
-    !  YMD (Year Month Day) and TOD (Time-of-day) format.
-    !  Set the time by an integer as YYYYMMDD and integer seconds in the day
-
-    ! input/output parameters:
-    type(ESMF_Time)     , intent(inout)         :: Time ! ESMF time
-    integer             , intent(in)            :: ymd  ! year, month, day YYYYMMDD
-    type(ESMF_Calendar) , intent(in)            :: cal  ! ESMF calendar
-    integer             , intent(in),  optional :: tod  ! time of day in seconds
-    character(len=*)    , intent(in),  optional :: desc ! description of time to set
-    integer             , intent(in),  optional :: logunit
-    integer             , intent(out), optional :: rc
-
-    ! local varaibles
-    integer                     :: yr, mon, day ! Year, month, day as integers
-    integer                     :: ltod         ! local tod
-    character(len=256)          :: ldesc        ! local desc
-    character(len=*), parameter :: subname = '(TimeInit) '
-    !-------------------------------------------------------------------------------
-
-    ltod = 0
-    if (present(tod)) ltod = tod
-    ldesc = ''
-    if (present(desc)) ldesc = desc
-
-    if ( (ymd < 0) .or. (ltod < 0) .or. (ltod > SecPerDay) )then
-       if (present(logunit)) then
-          write(logunit,*) subname//': ERROR yymmdd is a negative number or '// &
-               'time-of-day out of bounds', ymd, ltod
-       end if
-       call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
-            msg=subname//' yymmdd is negative or time-of-day out of bounds ', &
-            line=__LINE__, &
-            file=__FILE__, rcToReturn=rc)
+  call ESMF_TimeGet(CurrTime, yy=nyy, mm=nmm, dd=ndd, s=nsec, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
        return
-    end if
 
-    call date2ymd (ymd,yr,mon,day)
+  ! initial guess of next alarm, this will be updated below
+  if (present(RefTime)) then
+     NextAlarm = RefTime
+  else
+     NextAlarm = CurrTime
+  endif
 
-    call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-         line=__LINE__, &
-         file=__FILE__)) &
-         return
+  ! Determine calendar
+  call ESMF_ClockGet(clock, calendar=cal, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
 
-  end subroutine TimeInit
+  ! Determine inputs for call to create alarm
+  selectcase (trim(option))
 
-  !===============================================================================
+  case (optNONE, optNever)
+     call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call ESMF_TimeSet( NextAlarm, yy=9999, mm=12, dd=1, s=0, calendar=cal, rc=rc )
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     update_nextalarm  = .false.
 
-  subroutine date2ymd (date, year, month, day)
+  case (optDate)
+     if (.not. present(opt_ymd)) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//trim(option)//' requires opt_ymd', &
+	     line=__LINE__, &
+	     file=__FILE__, rcToReturn=rc)
+	return
+     end if
+     if (lymd < 0 .or. ltod < 0) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//trim(option)//'opt_ymd, opt_tod invalid', &
+	     line=__LINE__, &
+	     file=__FILE__, rcToReturn=rc)
+	return
+     end if
+     call ESMF_TimeIntervalSet(AlarmInterval, yy=9999, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call TimeInit(NextAlarm, lymd, cal, tod=ltod, desc="optDate", rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     update_nextalarm  = .false.
 
-    ! input/output variables
-    integer, intent(in)  :: date             ! coded-date (yyyymmdd)
-    integer, intent(out) :: year,month,day   ! calendar year,month,day
+  case (optIfdays0)
+     if (.not. present(opt_ymd)) then
+	call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	     msg=subname//trim(option)//' requires opt_ymd', &
+	     line=__LINE__, &
+	     file=__FILE__, rcToReturn=rc)
+	return
+     end if
+     call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=opt_n, s=0, calendar=cal, rc=rc )
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     update_nextalarm  = .true.
 
-    ! local variables
-    integer :: tdate   ! temporary date
-    character(*),parameter :: subName = "(date2ymd)"
-    !-------------------------------------------------------------------------------
+  case (optNSteps, optNStep)
+     call ESMF_ClockGet(clock, TimeStep=AlarmInterval, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
 
-    tdate = abs(date)
-    year = int(tdate/10000)
-    if (date < 0) then
-       year = -year
-    end if
-    month = int( mod(tdate,10000)/  100)
-    day = mod(tdate,  100)
+  case (optNSeconds, optNSecond)
+     call ESMF_TimeIntervalSet(AlarmInterval, s=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
 
-  end subroutine date2ymd
+  case (optNMinutes, optNMinute)
+     call ESMF_TimeIntervalSet(AlarmInterval, s=60, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
+
+  case (optNHours, optNHour)
+     call ESMF_TimeIntervalSet(AlarmInterval, s=3600, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
+
+  case (optNDays, optNDay)
+     call ESMF_TimeIntervalSet(AlarmInterval, d=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
+
+  case (optNMonths, optNMonth)
+     call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
+
+  case (optMonthly)
+     call ESMF_TimeIntervalSet(AlarmInterval, mm=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call ESMF_TimeSet( NextAlarm, yy=cyy, mm=cmm, dd=1, s=0, calendar=cal, rc=rc )
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     update_nextalarm  = .true.
+
+  case (optNYears, optNYear)
+     call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     AlarmInterval = AlarmInterval * opt_n
+     update_nextalarm  = .true.
+
+  case (optYearly)
+     call ESMF_TimeIntervalSet(AlarmInterval, yy=1, rc=rc)
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     call ESMF_TimeSet( NextAlarm, yy=cyy, mm=1, dd=1, s=0, calendar=cal, rc=rc )
+     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+	  line=__LINE__, &
+	  file=__FILE__)) &
+	  return
+     update_nextalarm  = .true.
+
+  case default
+     call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	  msg=subname//' unknown option: '//trim(option), &
+	  line=__LINE__, &
+	  file=__FILE__, rcToReturn=rc)
+     return
+
+  end select
+
+  ! --------------------------------------------------------------------------------
+  ! --- AlarmInterval and NextAlarm should be set ---
+  ! --------------------------------------------------------------------------------
+
+  ! --- advance Next Alarm so it won't ring on first timestep for
+  ! --- most options above. go back one alarminterval just to be careful
+
+  if (update_nextalarm) then
+     NextAlarm = NextAlarm - AlarmInterval
+     do while (NextAlarm <= CurrTime)
+	NextAlarm = NextAlarm + AlarmInterval
+     enddo
+  endif
+
+  alarm = ESMF_AlarmCreate( name=lalarmname, clock=clock, ringTime=NextAlarm, ringInterval=AlarmInterval, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+
+end subroutine AlarmInit
+
+!===============================================================================
+
+subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
+
+  !  Create the ESMF_Time object corresponding to the given input time, given in
+  !  YMD (Year Month Day) and TOD (Time-of-day) format.
+  !  Set the time by an integer as YYYYMMDD and integer seconds in the day
+
+  ! input/output parameters:
+  type(ESMF_Time)     , intent(inout)         :: Time ! ESMF time
+  integer             , intent(in)            :: ymd  ! year, month, day YYYYMMDD
+  type(ESMF_Calendar) , intent(in)            :: cal  ! ESMF calendar
+  integer             , intent(in),  optional :: tod  ! time of day in seconds
+  character(len=*)    , intent(in),  optional :: desc ! description of time to set
+  integer             , intent(in),  optional :: logunit
+  integer             , intent(out), optional :: rc
+
+  ! local varaibles
+  integer                     :: yr, mon, day ! Year, month, day as integers
+  integer                     :: ltod         ! local tod
+  character(len=256)          :: ldesc        ! local desc
+  character(len=*), parameter :: subname = '(TimeInit) '
+  !-------------------------------------------------------------------------------
+
+  ltod = 0
+  if (present(tod)) ltod = tod
+  ldesc = ''
+  if (present(desc)) ldesc = desc
+
+  if ( (ymd < 0) .or. (ltod < 0) .or. (ltod > SecPerDay) )then
+     if (present(logunit)) then
+	write(logunit,*) subname//': ERROR yymmdd is a negative number or '// &
+	     'time-of-day out of bounds', ymd, ltod
+     end if
+     call ESMF_LogSetError(ESMF_RC_ARG_BAD, &
+	  msg=subname//' yymmdd is negative or time-of-day out of bounds ', &
+	  line=__LINE__, &
+	  file=__FILE__, rcToReturn=rc)
+     return
+  end if
+
+  call date2ymd (ymd,yr,mon,day)
+
+  call ESMF_TimeSet( Time, yy=yr, mm=mon, dd=day, s=ltod, calendar=cal, rc=rc )
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__, &
+       file=__FILE__)) &
+       return
+
+end subroutine TimeInit
+
+!===============================================================================
+
+subroutine date2ymd (date, year, month, day)
+
+  ! input/output variables
+  integer, intent(in)  :: date             ! coded-date (yyyymmdd)
+  integer, intent(out) :: year,month,day   ! calendar year,month,day
+
+  ! local variables
+  integer :: tdate   ! temporary date
+  character(*),parameter :: subName = "(date2ymd)"
+  !-------------------------------------------------------------------------------
+
+  tdate = abs(date)
+  year = int(tdate/10000)
+  if (date < 0) then
+     year = -year
+  end if
+  month = int( mod(tdate,10000)/  100)
+  day = mod(tdate,  100)
+
+end subroutine date2ymd
 
 end module

--- a/config_src/nuopc_driver/mom_cap_time.F90
+++ b/config_src/nuopc_driver/mom_cap_time.F90
@@ -1,11 +1,9 @@
-!
-! This was originally share code in CIME, but required CIME as a
-! dependency to build the MOM cap.  The options here for setting
-! a restart alarm are useful for all caps, so a second step is to
-! determine if/how these could be offered more generally in a
-! shared library.  For now we really want the MOM cap to only
-! depend on MOM and ESMF/NUOPC.
-!
+!> This was originally share code in CIME, but required CIME as a
+!! dependency to build the MOM cap.  The options here for setting
+!! a restart alarm are useful for all caps, so a second step is to
+!! determine if/how these could be offered more generally in a
+!! shared library.  For now we really want the MOM cap to only
+!! depend on MOM and ESMF/NUOPC.
 module mom_cap_time
 
 ! !USES:
@@ -55,37 +53,31 @@ integer, parameter          :: SecPerDay = 86400 ! Seconds per day
 character(len=*), parameter :: u_FILE_u = &
      __FILE__
 
-!===============================================================================
 contains
-!===============================================================================
 
+!> Setup an alarm in a clock. The ringtime sent to AlarmCreate
+!! MUST be the next alarm time.  If you send an arbitrary but
+!! proper ringtime from the past and the ring interval, the alarm
+!! will always go off on the next clock advance and this will cause
+!! serious problems. Even if it makes sense to initialize an alarm
+!! with some reference time and the alarm interval, that reference
+!! time has to be advance forward to be >= the current time.
+!! In the logic below  we set an appropriate "NextAlarm" and then
+!! we make sure to advance it properly based on the ring interval.
 subroutine AlarmInit( clock, alarm, option, &
      opt_n, opt_ymd, opt_tod, RefTime, alarmname, rc)
-
-  ! !DESCRIPTION: Setup an alarm in a clock
-  ! Notes: The ringtime sent to AlarmCreate MUST be the next alarm
-  ! time.  If you send an arbitrary but proper ringtime from the
-  ! past and the ring interval, the alarm will always go off on the
-  ! next clock advance and this will cause serious problems.  Even
-  ! if it makes sense to initialize an alarm with some reference
-  ! time and the alarm interval, that reference time has to be
-  ! advance forward to be >= the current time.  In the logic below
-  ! we set an appropriate "NextAlarm" and then we make sure to
-  ! advance it properly based on the ring interval.
-
-  ! input/output variables
-  type(ESMF_Clock)            , intent(inout) :: clock     ! clock
-  type(ESMF_Alarm)            , intent(inout) :: alarm     ! alarm
-  character(len=*)            , intent(in)    :: option    ! alarm option
-  integer          , optional , intent(in)    :: opt_n     ! alarm freq
-  integer          , optional , intent(in)    :: opt_ymd   ! alarm ymd
-  integer          , optional , intent(in)    :: opt_tod   ! alarm tod (sec)
-  type(ESMF_Time)  , optional , intent(in)    :: RefTime   ! ref time
-  character(len=*) , optional , intent(in)    :: alarmname ! alarm name
-  integer                     , intent(inout) :: rc        ! Return code
+  type(ESMF_Clock)            , intent(inout) :: clock     !< ESMF clock
+  type(ESMF_Alarm)            , intent(inout) :: alarm     !< ESMF alarm
+  character(len=*)            , intent(in)    :: option    !< alarm option
+  integer          , optional , intent(in)    :: opt_n     !< alarm freq
+  integer          , optional , intent(in)    :: opt_ymd   !< alarm ymd
+  integer          , optional , intent(in)    :: opt_tod   !< alarm tod (sec)
+  type(ESMF_Time)  , optional , intent(in)    :: RefTime   !< ref time
+  character(len=*) , optional , intent(in)    :: alarmname !< alarm name
+  integer                     , intent(inout) :: rc        !< Return code
 
   ! local variables
-  type(ESMF_Calendar)     :: cal                ! calendar
+  type(ESMF_Calendar)     :: cal              ! calendar
   integer                 :: lymd             ! local ymd
   integer                 :: ltod             ! local tod
   integer                 :: cyy,cmm,cdd,csec ! time info
@@ -347,22 +339,17 @@ subroutine AlarmInit( clock, alarm, option, &
 
 end subroutine AlarmInit
 
-!===============================================================================
-
+!> Creates the ESMF_Time object corresponding to the given input time,
+!! given in YMD (Year Month Day) and TOD (Time-of-day) format. Sets
+!! the time by an integer as YYYYMMDD and integer seconds in the day.
 subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
-
-  !  Create the ESMF_Time object corresponding to the given input time, given in
-  !  YMD (Year Month Day) and TOD (Time-of-day) format.
-  !  Set the time by an integer as YYYYMMDD and integer seconds in the day
-
-  ! input/output parameters:
-  type(ESMF_Time)     , intent(inout)         :: Time ! ESMF time
-  integer             , intent(in)            :: ymd  ! year, month, day YYYYMMDD
-  type(ESMF_Calendar) , intent(in)            :: cal  ! ESMF calendar
-  integer             , intent(in),  optional :: tod  ! time of day in seconds
-  character(len=*)    , intent(in),  optional :: desc ! description of time to set
-  integer             , intent(in),  optional :: logunit
-  integer             , intent(out), optional :: rc
+  type(ESMF_Time)     , intent(inout)         :: Time !< ESMF time
+  integer             , intent(in)            :: ymd  !< year, month, day YYYYMMDD
+  type(ESMF_Calendar) , intent(in)            :: cal  !< ESMF calendar
+  integer             , intent(in),  optional :: tod  !< time of day in [sec]
+  character(len=*)    , intent(in),  optional :: desc !< description of time to set
+  integer             , intent(in),  optional :: logunit!< Unit for stdout output
+  integer             , intent(out), optional :: rc   !< Return code
 
   ! local varaibles
   integer                     :: yr, mon, day ! Year, month, day as integers
@@ -398,13 +385,10 @@ subroutine TimeInit( Time, ymd, cal, tod, desc, logunit, rc)
 
 end subroutine TimeInit
 
-!===============================================================================
-
+!> Converts a coded-date (yyyymmdd) into calendar year,month,day.
 subroutine date2ymd (date, year, month, day)
-
-  ! input/output variables
-  integer, intent(in)  :: date             ! coded-date (yyyymmdd)
-  integer, intent(out) :: year,month,day   ! calendar year,month,day
+  integer, intent(in)  :: date             !< coded-date (yyyymmdd)
+  integer, intent(out) :: year,month,day   !< calendar year,month,day
 
   ! local variables
   integer :: tdate   ! temporary date

--- a/config_src/nuopc_driver/time_utils.F90
+++ b/config_src/nuopc_driver/time_utils.F90
@@ -1,4 +1,4 @@
-!> Set of subroutines that convert date/time between FMS and ESMF formats.
+!> Set of time utilities for converting between FMS and ESMF time type.
 module time_utils_mod
 
 ! FMS

--- a/config_src/nuopc_driver/time_utils.F90
+++ b/config_src/nuopc_driver/time_utils.F90
@@ -1,3 +1,4 @@
+!> Set of subroutines that convert date/time between FMS and ESMF formats.
 module time_utils_mod
 
 use fms_mod,                  only: uppercase
@@ -9,11 +10,13 @@ use ESMF
 
 implicit none; private
 
-!-------------------- interface blocks ---------------------
+!> Converts calendar from FMS to ESMF format
 interface fms2esmf_cal
   module procedure fms2esmf_cal_c
   module procedure fms2esmf_cal_i
 end interface fms2esmf_cal
+
+!> Converts time from FMS to ESMF format
 interface esmf2fms_time
   module procedure esmf2fms_time_t
   module procedure esmf2fms_timestep
@@ -26,13 +29,10 @@ public string_to_date
 
 contains
 
-!-------------------- module code ---------------------
-
+!> Sets fms2esmf_cal_c to the corresponding ESMF calendar type
 function fms2esmf_cal_c(calendar)
-!    ! Return Value:
-  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_c
-!    ! Arguments:
-  character(len=*), intent(in)       :: calendar
+  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_c !< ESMF calendar type
+  character(len=*), intent(in)       :: calendar       !< Type of calendar
 
   select case( uppercase(trim(calendar)) )
   case( 'GREGORIAN' )
@@ -51,11 +51,10 @@ function fms2esmf_cal_c(calendar)
   end select
 end function fms2esmf_cal_c
 
+!> Sets fms2esmf_cal_i to the corresponding ESMF calendar type
 function fms2esmf_cal_i(calendar)
-!    ! Return Value:
-  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_i
-!    ! Arguments:
-  integer, intent(in)                :: calendar
+  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_i !< ESMF calendar structure
+  integer, intent(in)                :: calendar       !< Type of calendar
 
   select case(calendar)
     case(THIRTY_DAY_MONTHS)
@@ -71,11 +70,11 @@ function fms2esmf_cal_i(calendar)
   end select
 end function fms2esmf_cal_i
 
+!> Converts date from ESMF format to FMS format.
 function esmf2fms_time_t(time)
-  ! Return Value
-  type(Time_type)                    :: esmf2fms_time_t
-  ! Input Arguments
-  type(ESMF_Time), intent(in)        :: time
+  type(Time_type)                    :: esmf2fms_time_t !< FMS time structure
+  type(ESMF_Time), intent(in)        :: time            !< ESMF time structure
+
   ! Local Variables
   integer                            :: yy, mm, dd, h, m, s
   type(ESMF_CALKIND_FLAG)            :: calkind
@@ -89,15 +88,15 @@ function esmf2fms_time_t(time)
     file=__FILE__)) &
     return  ! bail out
 
-  esmf2fms_time_t = Set_date(yy, mm, dd, h, m, s)
+  esmf2fms_time_t = set_date(yy, mm, dd, h, m, s)
 
 end function esmf2fms_time_t
 
+!> Converts time-interval from ESMF format to FMS format.
 function esmf2fms_timestep(timestep)
-  ! Return Value
-  type(Time_type)                    :: esmf2fms_timestep
-  ! Input Arguments
-  type(ESMF_TimeInterval), intent(in):: timestep
+  type(Time_type)                    :: esmf2fms_timestep !< FMS time structure
+  type(ESMF_TimeInterval), intent(in):: timestep          !< time-interval following
+                                                          !! ESMF format [s]
   ! Local Variables
   integer                            :: s
   type(ESMF_CALKIND_FLAG)            :: calkind
@@ -114,12 +113,12 @@ function esmf2fms_timestep(timestep)
 
 end function esmf2fms_timestep
 
+!> Converts date from FMS format to ESMF format.
 function fms2esmf_time(time, calkind)
-  ! Return Value
-  type(ESMF_Time)                    :: fms2esmf_time
-  ! Input Arguments
-  type(Time_type), intent(in)        :: time
-  type(ESMF_CALKIND_FLAG), intent(in), optional :: calkind
+  type(ESMF_Time)                    :: fms2esmf_time !< ESMF time structure
+  type(time_type), intent(in)        :: time          !< FMS time structure
+  type(ESMF_CALKIND_FLAG), intent(in), optional :: calkind !< ESMF calendar structure
+
   ! Local Variables
   integer                            :: yy, mm, d, h, m, s
   type(ESMF_CALKIND_FLAG)            :: l_calkind
@@ -143,11 +142,14 @@ function fms2esmf_time(time, calkind)
 
 end function fms2esmf_time
 
+!> Converts a string (I4.4,I2.2,I2.2,".",I2.2,I2.2,I2.2) that represents
+!! yr, mon, day, hr, min, sec to a FMS data format.
 function string_to_date(string, rc)
-  character(len=15), intent(in)           :: string
-  integer, intent(out), optional          :: rc
-  type(time_type)                         :: string_to_date
+  character(len=15), intent(in)           :: string        !< String representing a date
+  integer, intent(out), optional          :: rc            !< ESMF error handler
+  type(time_type)                         :: string_to_date!< FMS time structure
 
+  ! Local variables
   integer                                 :: yr,mon,day,hr,min,sec
 
   if(present(rc)) rc = ESMF_SUCCESS

--- a/config_src/nuopc_driver/time_utils.F90
+++ b/config_src/nuopc_driver/time_utils.F90
@@ -1,161 +1,160 @@
 module time_utils_mod
 
-  use fms_mod,                  only: uppercase
-  use mpp_mod,                  only: mpp_error, FATAL
-  use time_manager_mod,         only: time_type, set_time, set_date, get_date
-  use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
-  use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
-  use ESMF
+use fms_mod,                  only: uppercase
+use mpp_mod,                  only: mpp_error, FATAL
+use time_manager_mod,         only: time_type, set_time, set_date, get_date
+use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
+use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
+use ESMF
 
-  implicit none
-  private
+implicit none; private
 
-  !-------------------- interface blocks ---------------------
-  interface fms2esmf_cal
-    module procedure fms2esmf_cal_c
-    module procedure fms2esmf_cal_i
-  end interface fms2esmf_cal
-  interface esmf2fms_time
-    module procedure esmf2fms_time_t
-    module procedure esmf2fms_timestep
-  end interface esmf2fms_time
+!-------------------- interface blocks ---------------------
+interface fms2esmf_cal
+  module procedure fms2esmf_cal_c
+  module procedure fms2esmf_cal_i
+end interface fms2esmf_cal
+interface esmf2fms_time
+  module procedure esmf2fms_time_t
+  module procedure esmf2fms_timestep
+end interface esmf2fms_time
 
-  public fms2esmf_cal
-  public esmf2fms_time
-  public fms2esmf_time
-  public string_to_date
+public fms2esmf_cal
+public esmf2fms_time
+public fms2esmf_time
+public string_to_date
 
-  contains
+contains
 
-  !-------------------- module code ---------------------
+!-------------------- module code ---------------------
 
-  function fms2esmf_cal_c(calendar)
+function fms2esmf_cal_c(calendar)
 !    ! Return Value:
-    type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_c
+  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_c
 !    ! Arguments:
-    character(len=*), intent(in)       :: calendar
+  character(len=*), intent(in)       :: calendar
 
-    select case( uppercase(trim(calendar)) )
-    case( 'GREGORIAN' )
-      fms2esmf_cal_c = ESMF_CALKIND_GREGORIAN
-    case( 'JULIAN' )
-      fms2esmf_cal_c = ESMF_CALKIND_JULIAN
-    case( 'NOLEAP' )
-      fms2esmf_cal_c = ESMF_CALKIND_NOLEAP
-    case( 'THIRTY_DAY' )
-      fms2esmf_cal_c = ESMF_CALKIND_360DAY
-    case( 'NO_CALENDAR' )
-      fms2esmf_cal_c = ESMF_CALKIND_NOCALENDAR
-    case default
-      call mpp_error(FATAL, &
-      'ocean_solo: ocean_solo_nml entry calendar must be one of GREGORIAN|JULIAN|NOLEAP|THIRTY_DAY|NO_CALENDAR.' )
-    end select
-  end function fms2esmf_cal_c
+  select case( uppercase(trim(calendar)) )
+  case( 'GREGORIAN' )
+    fms2esmf_cal_c = ESMF_CALKIND_GREGORIAN
+  case( 'JULIAN' )
+    fms2esmf_cal_c = ESMF_CALKIND_JULIAN
+  case( 'NOLEAP' )
+    fms2esmf_cal_c = ESMF_CALKIND_NOLEAP
+  case( 'THIRTY_DAY' )
+    fms2esmf_cal_c = ESMF_CALKIND_360DAY
+  case( 'NO_CALENDAR' )
+    fms2esmf_cal_c = ESMF_CALKIND_NOCALENDAR
+  case default
+    call mpp_error(FATAL, &
+    'ocean_solo: ocean_solo_nml entry calendar must be one of GREGORIAN|JULIAN|NOLEAP|THIRTY_DAY|NO_CALENDAR.' )
+  end select
+end function fms2esmf_cal_c
 
-  function fms2esmf_cal_i(calendar)
+function fms2esmf_cal_i(calendar)
 !    ! Return Value:
-    type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_i
+  type(ESMF_CALKIND_FLAG)            :: fms2esmf_cal_i
 !    ! Arguments:
-    integer, intent(in)                :: calendar
+  integer, intent(in)                :: calendar
 
-    select case(calendar)
-      case(THIRTY_DAY_MONTHS)
-        fms2esmf_cal_i = ESMF_CALKIND_360DAY
-      case(GREGORIAN)
-        fms2esmf_cal_i = ESMF_CALKIND_GREGORIAN
-      case(JULIAN)
-        fms2esmf_cal_i = ESMF_CALKIND_JULIAN
-      case(NOLEAP)
-        fms2esmf_cal_i = ESMF_CALKIND_NOLEAP
-      case(NO_CALENDAR)
-        fms2esmf_cal_i = ESMF_CALKIND_NOCALENDAR
-    end select
-  end function fms2esmf_cal_i
+  select case(calendar)
+    case(THIRTY_DAY_MONTHS)
+      fms2esmf_cal_i = ESMF_CALKIND_360DAY
+    case(GREGORIAN)
+      fms2esmf_cal_i = ESMF_CALKIND_GREGORIAN
+    case(JULIAN)
+      fms2esmf_cal_i = ESMF_CALKIND_JULIAN
+    case(NOLEAP)
+      fms2esmf_cal_i = ESMF_CALKIND_NOLEAP
+    case(NO_CALENDAR)
+      fms2esmf_cal_i = ESMF_CALKIND_NOCALENDAR
+  end select
+end function fms2esmf_cal_i
 
-  function esmf2fms_time_t(time)
-    ! Return Value
-    type(Time_type)                    :: esmf2fms_time_t
-    ! Input Arguments
-    type(ESMF_Time), intent(in)        :: time
-    ! Local Variables
-    integer                            :: yy, mm, dd, h, m, s
-    type(ESMF_CALKIND_FLAG)            :: calkind
+function esmf2fms_time_t(time)
+  ! Return Value
+  type(Time_type)                    :: esmf2fms_time_t
+  ! Input Arguments
+  type(ESMF_Time), intent(in)        :: time
+  ! Local Variables
+  integer                            :: yy, mm, dd, h, m, s
+  type(ESMF_CALKIND_FLAG)            :: calkind
 
-    integer                            :: rc
+  integer                            :: rc
 
-    call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, &
-        calkindflag=calkind, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call ESMF_TimeGet(time, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, &
+      calkindflag=calkind, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    esmf2fms_time_t = Set_date(yy, mm, dd, h, m, s)
+  esmf2fms_time_t = Set_date(yy, mm, dd, h, m, s)
 
-  end function esmf2fms_time_t
+end function esmf2fms_time_t
 
-  function esmf2fms_timestep(timestep)
-    ! Return Value
-    type(Time_type)                    :: esmf2fms_timestep
-    ! Input Arguments
-    type(ESMF_TimeInterval), intent(in):: timestep
-    ! Local Variables
-    integer                            :: s
-    type(ESMF_CALKIND_FLAG)            :: calkind
+function esmf2fms_timestep(timestep)
+  ! Return Value
+  type(Time_type)                    :: esmf2fms_timestep
+  ! Input Arguments
+  type(ESMF_TimeInterval), intent(in):: timestep
+  ! Local Variables
+  integer                            :: s
+  type(ESMF_CALKIND_FLAG)            :: calkind
 
-    integer                            :: rc
+  integer                            :: rc
 
-    call ESMF_TimeIntervalGet(timestep, s=s, calkindflag=calkind, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call ESMF_TimeIntervalGet(timestep, s=s, calkindflag=calkind, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-    esmf2fms_timestep = set_time(s, 0)
+  esmf2fms_timestep = set_time(s, 0)
 
-  end function esmf2fms_timestep
+end function esmf2fms_timestep
 
-  function fms2esmf_time(time, calkind)
-    ! Return Value
-    type(ESMF_Time)                    :: fms2esmf_time
-    ! Input Arguments
-    type(Time_type), intent(in)        :: time
-    type(ESMF_CALKIND_FLAG), intent(in), optional :: calkind
-    ! Local Variables
-    integer                            :: yy, mm, d, h, m, s
-    type(ESMF_CALKIND_FLAG)            :: l_calkind
+function fms2esmf_time(time, calkind)
+  ! Return Value
+  type(ESMF_Time)                    :: fms2esmf_time
+  ! Input Arguments
+  type(Time_type), intent(in)        :: time
+  type(ESMF_CALKIND_FLAG), intent(in), optional :: calkind
+  ! Local Variables
+  integer                            :: yy, mm, d, h, m, s
+  type(ESMF_CALKIND_FLAG)            :: l_calkind
 
-    integer                            :: rc
+  integer                            :: rc
 
-    if(present(calkind)) then
-      l_calkind = calkind
-    else
-      l_calkind = fms2esmf_cal(fms_get_calendar_type())
-    endif
+  if(present(calkind)) then
+    l_calkind = calkind
+  else
+    l_calkind = fms2esmf_cal(fms_get_calendar_type())
+  endif
 
-    call get_date(time, yy, mm, d, h, m, s)
+  call get_date(time, yy, mm, d, h, m, s)
 
-    call ESMF_TimeSet(fms2esmf_time, yy=yy, mm=mm, d=d, h=h, m=m, s=s, &
-        calkindflag=l_calkind, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+  call ESMF_TimeSet(fms2esmf_time, yy=yy, mm=mm, d=d, h=h, m=m, s=s, &
+      calkindflag=l_calkind, rc=rc)
+  if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+    line=__LINE__, &
+    file=__FILE__)) &
+    return  ! bail out
 
-  end function fms2esmf_time
+end function fms2esmf_time
 
-  function string_to_date(string, rc)
-    character(len=15), intent(in)           :: string
-    integer, intent(out), optional          :: rc
-    type(time_type)                         :: string_to_date
+function string_to_date(string, rc)
+  character(len=15), intent(in)           :: string
+  integer, intent(out), optional          :: rc
+  type(time_type)                         :: string_to_date
 
-    integer                                 :: yr,mon,day,hr,min,sec
+  integer                                 :: yr,mon,day,hr,min,sec
 
-    if(present(rc)) rc = ESMF_SUCCESS
+  if(present(rc)) rc = ESMF_SUCCESS
 
-    read(string, '(I4.4,I2.2,I2.2,".",I2.2,I2.2,I2.2)') yr, mon, day, hr, min, sec
-    string_to_date = set_date(yr, mon, day, hr, min, sec)
+  read(string, '(I4.4,I2.2,I2.2,".",I2.2,I2.2,I2.2)') yr, mon, day, hr, min, sec
+  string_to_date = set_date(yr, mon, day, hr, min, sec)
 
-  end function string_to_date
+end function string_to_date
 
 end module time_utils_mod

--- a/config_src/nuopc_driver/time_utils.F90
+++ b/config_src/nuopc_driver/time_utils.F90
@@ -1,12 +1,19 @@
 !> Set of subroutines that convert date/time between FMS and ESMF formats.
 module time_utils_mod
 
-use fms_mod,                  only: uppercase
-use mpp_mod,                  only: mpp_error, FATAL
-use time_manager_mod,         only: time_type, set_time, set_date, get_date
-use time_manager_mod,         only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
-use time_manager_mod,         only: fms_get_calendar_type => get_calendar_type
-use ESMF
+! FMS
+use fms_mod,            only: uppercase
+use mpp_mod,            only: mpp_error, FATAL
+use time_manager_mod,   only: time_type, set_time, set_date, get_date
+use time_manager_mod,   only: GREGORIAN, JULIAN, NOLEAP, THIRTY_DAY_MONTHS, NO_CALENDAR
+use time_manager_mod,   only: fms_get_calendar_type => get_calendar_type
+! ESMF
+use ESMF,               only: ESMF_CALKIND_FLAG, ESMF_CALKIND_GREGORIAN
+use ESMF,               only: ESMF_CALKIND_JULIAN, ESMF_CALKIND_NOLEAP
+use ESMF,               only: ESMF_CALKIND_360DAY, ESMF_CALKIND_NOCALENDAR
+use ESMF,               only: ESMF_Time, ESMF_TimeGet, ESMF_LogFoundError
+use ESMF,               only: ESMF_LOGERR_PASSTHRU,ESMF_TimeInterval
+use ESMF,               only: ESMF_TimeIntervalGet, ESMF_TimeSet, ESMF_SUCCESS
 
 implicit none; private
 


### PR DESCRIPTION
I've addressed the following issues mentioned in #899:

* Add use statements with the "only" attribute;
* Fix code-style issues;
* Add doxygen comments;
* Keep "implicit none ; private" in the same line.

TODO:
* In mom_cap.F90, ESMF_GridCompGetInternalState does not have an explicit Fortran interface. Therefore, the model does not compile with "use ESMF,  only: ESMF_GridCompGetInternalState" but it does build sucessfully when this is removed (via CESM). Is this okay?
* In mom_cap.F90, subroutine DataInitialize needs to be described;
* I have not docummented all the local variables but I think this is okay for now.

